### PR TITLE
Update Json rule engine namespaces

### DIFF
--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine;
 using Microsoft.Azure.Templates.Analyzer.TemplateProcessor;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
@@ -55,9 +56,14 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
             try
             {
                 var rules = LoadRules();
-                var jsonRuleEngine = new JsonEngine.JsonRuleEngine(new JsonLineNumberResolver());
+                var jsonRuleEngine = new JsonRuleEngine(new JsonLineNumberResolver());
 
-                IEnumerable<IResult> results = jsonRuleEngine.EvaluateRules(new TemplateContext { OriginalTemplate = JObject.Parse(Template), ExpandedTemplate = templatejObject, IsMainTemplate = true }, rules);
+                IEnumerable<IResult> results = jsonRuleEngine.EvaluateRules(
+                    new TemplateContext {
+                        OriginalTemplate = JObject.Parse(Template),
+                        ExpandedTemplate = templatejObject,
+                        IsMainTemplate = true },
+                    rules);
 
                 return results;
             }

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
@@ -5,7 +5,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <AssemblyName>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.FunctionalTests</AssemblyName>
+    <AssemblyName>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests</AssemblyName>
 
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.FunctionalTests</RootNamespace>
   </PropertyGroup>

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
@@ -7,7 +7,7 @@
 
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests</AssemblyName>
 
-    <RootNamespace>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.FunctionalTests</RootNamespace>
+    <RootNamespace>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/RuleParsingTests.cs
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/RuleParsingTests.cs
@@ -4,10 +4,13 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Newtonsoft.Json;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.FunctionalTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class OperatorSpecificValidatorAttribute : Attribute

--- a/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
@@ -5,9 +5,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <AssemblyName>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests</AssemblyName>
+    <AssemblyName>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests</AssemblyName>
 
-    <RootNamespace>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests</RootNamespace>
+    <RootNamespace>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Analyzer.JsonRuleEngine.UnitTests/EqualsOperatorTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/EqualsOperatorTests.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class EqualsOperatorTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/ExistsOperatorTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/ExistsOperatorTests.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class ExistsOperatorTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionConverterTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionConverterTests.cs
@@ -2,14 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
-using Newtonsoft.Json;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Collections.Generic;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Converters;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class ExpressionConverterTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/HasValueOperatorTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/HasValueOperatorTests.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class HasValueOperatorTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEngineTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEngineTests.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class JsonRuleEngineTests
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
                     It.Is<JToken>(templateContext.OriginalTemplate, EqualityComparer<object>.Default)))
                 .Returns(expectedLineNumber);
 
-            var ruleEngine = new JsonEngine.JsonRuleEngine(mockLineResolver.Object);
+            var ruleEngine = new JsonRuleEngine(mockLineResolver.Object);
             var results = ruleEngine.EvaluateRules(templateContext, rules).ToList();
 
             Assert.AreEqual(evaluations.Length, results.Count());
@@ -93,7 +94,7 @@ namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
         [ExpectedException(typeof(ArgumentNullException))]
         public void Constructor_NullLineNumberResolver_ThrowsException()
         {
-            new JsonEngine.JsonRuleEngine(null);
+            new JsonRuleEngine(null);
         }
 
         private string CreateRulesFromEvaluations(string[] evaluations)

--- a/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleResultTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleResultTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class JsonRuleResultTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionDefinitionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionDefinitionTests.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class LeafExpressionDefinitionTests

--- a/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Linq;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using Moq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 {
     [TestClass]
     public class LeafExpressionTests

--- a/src/Analyzer.JsonRuleEngine/Analyzer.JsonRuleEngine.csproj
+++ b/src/Analyzer.JsonRuleEngine/Analyzer.JsonRuleEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine</AssemblyName>
-    <RootNamespace>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine</RootNamespace>
+    <RootNamespace>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Analyzer.JsonRuleEngine/Converters/ExpressionConverter.cs
+++ b/src/Analyzer.JsonRuleEngine/Converters/ExpressionConverter.cs
@@ -6,10 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Converters
 {
     internal class ExpressionConverter : JsonConverter<ExpressionDefinition>
     {

--- a/src/Analyzer.JsonRuleEngine/Expressions/Expression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/Expression.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.Templates.Analyzer.Types;
 using System.Collections.Generic;
+using Microsoft.Azure.Templates.Analyzer.Types;
 
 namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
 {

--- a/src/Analyzer.JsonRuleEngine/Expressions/Expression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/Expression.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Templates.Analyzer.Types;
 using System.Collections.Generic;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
 {
     /// <summary>
     /// The base class for all Expressions in JSON rules.

--- a/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
+using Microsoft.Azure.Templates.Analyzer.Types;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
 {
     /// <summary>
     /// Represents a leaf expression in a JSON rule.

--- a/src/Analyzer.JsonRuleEngine/InternalsVisibleTo.cs
+++ b/src/Analyzer.JsonRuleEngine/InternalsVisibleTo.cs
@@ -3,8 +3,8 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests")]
-[assembly: InternalsVisibleTo("Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.FunctionalTests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests")]
 
 // For Moq testing library
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Analyzer.JsonRuleEngine/JsonRuleEngine.cs
+++ b/src/Analyzer.JsonRuleEngine/JsonRuleEngine.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.Templates.Analyzer.JsonRuleEngine;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
 {
     /// <summary>
     /// Evaluation engine for rules authored in JSON

--- a/src/Analyzer.JsonRuleEngine/JsonRuleResult.cs
+++ b/src/Analyzer.JsonRuleEngine/JsonRuleResult.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 using Microsoft.Azure.Templates.Analyzer.Types;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
 {
     /// <summary>
     /// Describes the result of a TemplateAnalyzer JSON rule against an ARM template.

--- a/src/Analyzer.JsonRuleEngine/Operators/EqualsOperator.cs
+++ b/src/Analyzer.JsonRuleEngine/Operators/EqualsOperator.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
 {
     internal class EqualsOperator : LeafExpressionOperator
     {

--- a/src/Analyzer.JsonRuleEngine/Operators/ExistsOperator.cs
+++ b/src/Analyzer.JsonRuleEngine/Operators/ExistsOperator.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
 {
     /// <summary>
     /// An operator that evaluates the "exists" JSON expression.

--- a/src/Analyzer.JsonRuleEngine/Operators/HasValueOperator.cs
+++ b/src/Analyzer.JsonRuleEngine/Operators/HasValueOperator.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
 {
     /// <summary>
     /// An operator that evaluates the "hasValue" JSON expression.

--- a/src/Analyzer.JsonRuleEngine/Operators/LeafExpressionOperator.cs
+++ b/src/Analyzer.JsonRuleEngine/Operators/LeafExpressionOperator.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
 {
     /// <summary>
     /// The base class for a concrete implementation of an operator in a JSON rule expression

--- a/src/Analyzer.JsonRuleEngine/Schema/ExpressionDefinition.cs
+++ b/src/Analyzer.JsonRuleEngine/Schema/ExpressionDefinition.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Converters;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas
 {
     /// <summary>
     /// The base class for all Expression schemas in JSON rules.

--- a/src/Analyzer.JsonRuleEngine/Schema/LeafExpressionDefinition.cs
+++ b/src/Analyzer.JsonRuleEngine/Schema/LeafExpressionDefinition.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
+using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas
 {
     /// <summary>
     /// The schema for leaf expressions in JSON rules.

--- a/src/Analyzer.JsonRuleEngine/Schema/RuleDefinition.cs
+++ b/src/Analyzer.JsonRuleEngine/Schema/RuleDefinition.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas
 {
     /// <summary>
     /// Represents a rule written in JSON.

--- a/src/Analyzer.Types/IJsonPathResolver.cs
+++ b/src/Analyzer.Types/IJsonPathResolver.cs
@@ -4,12 +4,12 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.Types
 {
     /// <summary>
-    /// A utility interface for resolving a JSON path in a JSON scope.
+    /// An interface for working with a JSON scope.
     /// </summary>
-    internal interface IJsonPathResolver
+    public interface IJsonPathResolver
     {
         /// <summary>
         /// Gets the JToken of the resolver's scope.

--- a/src/Analyzer.Utilities.UnitTests/JsonPathResolverTests.cs
+++ b/src/Analyzer.Utilities.UnitTests/JsonPathResolverTests.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Azure.Templates.Analyzer.Utilities
+namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
 {
     [TestClass]
     public class JsonPathResolverTests

--- a/src/Analyzer.Utilities.UnitTests/JsonPathResolverTests.cs
+++ b/src/Analyzer.Utilities.UnitTests/JsonPathResolverTests.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine.UnitTests
+namespace Microsoft.Azure.Templates.Analyzer.Utilities
 {
     [TestClass]
     public class JsonPathResolverTests

--- a/src/Analyzer.Utilities/Analyzer.Utilities.csproj
+++ b/src/Analyzer.Utilities/Analyzer.Utilities.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Analyzer.Types\Analyzer.Types.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Analyzer.Utilities/FieldContent.cs
+++ b/src/Analyzer.Utilities/FieldContent.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.Utilities
 {
     /// <summary>
     /// The content and properties of a given JToken field.

--- a/src/Analyzer.Utilities/JsonPathResolver.cs
+++ b/src/Analyzer.Utilities/JsonPathResolver.cs
@@ -4,15 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Azure.Templates.Analyzer.Utilities;
+using Microsoft.Azure.Templates.Analyzer.Types;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Azure.Templates.Analyzer.JsonRuleEngine
+namespace Microsoft.Azure.Templates.Analyzer.Utilities
 {
     /// <summary>
     /// An <c>IJsonPathResolver</c> to resolve JSON paths.
     /// </summary>
-    internal class JsonPathResolver : IJsonPathResolver
+    public class JsonPathResolver : IJsonPathResolver
     {
         private readonly JToken currentScope;
         private readonly string currentPath;


### PR DESCRIPTION
- Expanded namespaces within the Json rule engine
  - Namespace renamed from `Microsoft.Azure.Templates.Analyzer.JsonRuleEngine` to `Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine` so JsonRuleEngine isn't a namespace and class name
  - Kept the AssemblyName of the Json rule engine the same, since "....Analyzer.JsonRuleEngine.dll" seems like a better file name.
- Moved converter, operators, evaluations, and schemas into their own namespaces
- Moved `JsonPathResolver` to Utilities project, and its interface into Types (resolves issue #30)
- Updated test projects to mirror new namespace name