### PR TITLE
Fix null-ref exception in Equals operator

### DIFF
--- a/src/Analyzer.JsonRuleEngine.UnitTests/EqualsOperatorTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/EqualsOperatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
@@ -59,10 +60,27 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             Assert.IsTrue(notEqualsOperator.EvaluateExpression(actualValueJToken));
         }
 
-        public static string GetArrayValuesDynamicDataDisplayName(MethodInfo methodInfo, object[] data)
+        [DataTestMethod]
+        [DataRow("value", DisplayName = "Missing property is not equal to string")]
+        [DataRow(true, DisplayName = "Missing property is not equal to boolean")]
+        [DataRow(1, DisplayName = "Missing property is not equal to integer")]
+        [DataRow(0.1, DisplayName = "Missing property is not equal to float")]
+        [DataRow(new string[] { "value1", "value2" }, DisplayName = "Missing property is not equal to array")]
+        [DataRow(@"{""property"": ""value11""}", DisplayName = "Missing property is not equal to object")]
+        public void EvaluateExpression_PropertyIsMissing_EqualsExpressionIsFalse_NotEqualsExpressionIsTrue(object expectedValue)
         {
-            return "Array values are not equal";
+            var expectedValueJToken = ToJToken(expectedValue);
+
+            // {"Equals": jTokenValue} is false
+            var equalsOperator = new EqualsOperator(expectedValueJToken, isNegative: false);
+            Assert.IsFalse(equalsOperator.EvaluateExpression(null));
+
+            // {"NotEquals": jTokenValue} is true
+            var notEqualsOperator = new EqualsOperator(expectedValueJToken, isNegative: true);
+            Assert.IsTrue(notEqualsOperator.EvaluateExpression(null));
         }
+
+        public static string GetArrayValuesDynamicDataDisplayName(MethodInfo _, object[] __) => "Array values are not equal";
 
         static IEnumerable<object[]> TestArrays()
         {
@@ -77,6 +95,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         {
             Assert.AreEqual("Equals", new EqualsOperator(new JObject(), false).Name);
             Assert.AreEqual("NotEquals", new EqualsOperator(new JObject(), true).Name);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullSpecifiedValue_ThrowsException()
+        {
+            new EqualsOperator(null, false);
         }
 
         // Creates JSON with 'value' as the value of a key, parses it, then selects that key.

--- a/src/Analyzer.JsonRuleEngine/Operators/EqualsOperator.cs
+++ b/src/Analyzer.JsonRuleEngine/Operators/EqualsOperator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
@@ -20,7 +21,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
         /// <param name="isNegative">Whether the result of EvaluateExpression() should be negated or not.</param>
         public EqualsOperator(JToken specifiedValue, bool isNegative)
         {
-            this.SpecifiedValue = specifiedValue;
+            this.SpecifiedValue = specifiedValue ?? throw new ArgumentNullException(nameof(specifiedValue));
             this.IsNegative = isNegative;
         }
 
@@ -31,6 +32,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators
         /// <returns>A value indicating whether or not the evaluation passed.</returns>
         public override bool EvaluateExpression(JToken tokenToEvaluate)
         {
+            // tokenToEvaluate will be false if a specified property in the JSON is not defined (does not exist).
+            // In this case, "equals" is by definition false.
+            if (tokenToEvaluate == null)
+            {
+                return this.IsNegative;
+            }
+
             var normalizedSpecifiedValue = NormalizeValue(this.SpecifiedValue);
             var normalizedTokenToEvaluate = NormalizeValue(tokenToEvaluate);
 


### PR DESCRIPTION
Fixes #99.

`EqualsOperator.EvaluateExpression()` now first checks the `JToken` passed in.  If it's `null`, it immediately returns.  The value it returns is determined by whether or not the operator is negated (`equals` vs. `notEquals`).

`EqualsOperator` now also enforces a non-null value to compare against when it's created.