### PR TITLE
Update to .NET 5, update build metadata, include VS Code tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Analyzer.Cli/bin/Debug/net5.0/TemplateAnalyzer.dll",
+
+            // Runs the CLI against the currently open ARM template file.
+            // Alternatively, change ${file} to the path of a template to analyze that file.
+            // Add "-p" and a path to the parameters file to use specific parameters
+            // when analyzing the template.
+            "args": [
+                "analyze-template",
+                "-t", "${file}",
+                //"-p", "path-to-parameters"
+            ],
+
+            "cwd": "${workspaceFolder}/src/Analyzer.Cli/bin/Debug/net5.0/",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/src/Analyzer.Cli/bin/Debug/net5.0/TemplateAnalyzer.dll",
 
-            // Runs the CLI against the currently open ARM template file.
+            // Runs the analyzer CLI, analyzing the file currently active/being viewed in VS Code.
             // Alternatively, change ${file} to the path of a template to analyze that file.
             // Add "-p" and a path to the parameters file to use specific parameters
             // when analyzing the template.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/TemplateAnalyzer.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/src/TemplateAnalyzer.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/Analyzer.Cli/Analyzer.Cli.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,16 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test",
+                "${workspaceFolder}/src/TemplateAnalyzer.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "clean",
             "command": "dotnet",
             "type": "process",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,21 @@
 # Contributing to the ARM Template BPA
-We welcome community contributions to the Template BPA. Please note that by participating in this project, you agree to abide by the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)  and terms of the [CLA](#contributor-license-agreement-cla).
+We welcome community contributions to the Template BPA. Please note that by participating in this project, you agree to abide by the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) and terms of the [CLA](#contributor-license-agreement-cla).
 
 ## Getting Started
-* If you haven't already, you will need [dotnet core sdk 3.1](https://dotnet.microsoft.com/download) (or later) installed locally to build and run this project.
+* If you haven't already, you will need the [.NET 5 SDK](https://dotnet.microsoft.com/download) installed locally to build and run this project.
 * Fork this repo (see [this forking guide](https://guides.github.com/activities/forking/) for more information).
 * Checkout the repo locally with `git clone git@github.com:{your_username}/template-analyzer.git`.
-* Build the .NET solution with `dotnet build`.
+* The .NET solution can be built with the `dotnet build` command.
  
 ## Developing
- 
+
+### Environment
+* [Visual Studio Code](https://code.visualstudio.com/) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) is a great way to get started.
+  * Start VS Code and open the root directory where the code is cloned locally (File->Open Folder...).
+* Run the `build` task (Terminal->Run Task...->build) in VS Code to build the Template BPA.
+* Try analyzing a template: open a template file in VS Code and then run the `.NET Core Launch (console)` launch configuration (Run->Start Debugging).
+  * Alternatively, modify the configuration in [launch.json](./.vs/launch.json) and specify a path to a template file, and optionally specify a path to a parameters file to use.
+
 ### Components
 The Template Analyzer solution is comprised of the following main components:
 * CLI (*[src\Analyzer.Cli](./src/Analyzer.Cli)*): The command-line tool to execute the Template BPA. This executable will pass template files to Analyzer.Core.
@@ -24,9 +31,10 @@ The Template Analyzer solution is comprised of the following main components:
 4. JSON Rule Engine evaluates the expressions specified in the `evaluation` section of the rule and generates results to identify the rule violation in the template.
  
 ### Running the tests
-Use `dotnet test` to run the full Template BPA test suite
+* Use the `dotnet test` command to run the full Template BPA test suite.
+* If using VS Code, run the tests with the `test` task (Terminal->Run Task...->test).
 
-### Contributing Rules
+### Contributing Analyzer Rules
 Review the [Authoring JSON Rules](./docs/authoring-json-rules.md) section to contribute to the built-in Template BPA rules.
 
 ### Coding Conventions
@@ -60,7 +68,7 @@ Please follow the below conventions when contributing to this project.
     }
     ```
 #### Tests
-High test code coverage is required to contribute to this project. This ensures the highest code quality. **80% test code coverage is required.** This project uses Microsoft.VisualStudio.TestTools.UnitTesting for its tests. 
+High test code coverage is required to contribute to this project. This ensures the highest code quality. At least **80% test code coverage is required.** This project uses Microsoft.VisualStudio.TestTools.UnitTesting for its tests. 
 Please follow the below conventions when contributing to this project.
 * Each .NET project should have its corresponding test project
 * Each class should have its corresponding test class

--- a/src/Analyzer.Cli/Analyzer.Cli.csproj
+++ b/src/Analyzer.Cli/Analyzer.Cli.csproj
@@ -2,13 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <AssemblyName>TemplateAnalyzer</AssemblyName>
+    <Description>A command line interface for Microsoft.Azure.Templates.Analyzer.Core - an ARM Template scanner for security misconfiguration and best practices</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DocumentationFile>bin\Analyzer.Cli.xml</DocumentationFile>
+    <DocumentationFile>bin\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Analyzer.Cli/Analyzer.Cli.csproj
+++ b/src/Analyzer.Cli/Analyzer.Cli.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>TemplateAnalyzer</AssemblyName>
-    <Description>A command line interface for Microsoft.Azure.Templates.Analyzer.Core - an ARM Template scanner for security misconfiguration and best practices</Description>
+    <Description>A command line interface for Microsoft.Azure.Templates.Analyzer.Core - an ARM template scanner for security misconfigurations and best practices</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Analyzer.Core.UnitTests/Analyzer.Core.UnitTests.csproj
+++ b/src/Analyzer.Core.UnitTests/Analyzer.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Analyzer.Core/Analyzer.Core.csproj
+++ b/src/Analyzer.Core/Analyzer.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Azure.Templates.Analyzer</RootNamespace>
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.Core</AssemblyName>
-    <Description>An ARM Template scanner for security misconfiguration and best practices</Description>
+    <Description>An ARM template scanner for security misconfigurations and best practices</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Analyzer.Core/Analyzer.Core.csproj
+++ b/src/Analyzer.Core/Analyzer.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Microsoft.Azure.Templates.Analyzer</RootNamespace>
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.Core</AssemblyName>
+    <Description>An ARM Template scanner for security misconfiguration and best practices</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Analyzer.TemplateProcessor.UnitTests/Analyzer.TemplateProcessor.UnitTests.csproj
+++ b/src/Analyzer.TemplateProcessor.UnitTests/Analyzer.TemplateProcessor.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Analyzer.Utilities.UnitTests/Analyzer.Utilities.UnitTests.csproj
+++ b/src/Analyzer.Utilities.UnitTests/Analyzer.Utilities.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.0.1-alpha</Version>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+  </PropertyGroup>
+</Project>

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
- Update CLI and test projects to use .NET 5
- Rename CLI output to TemplateAnalyzer (.exe and .dll)
- Add a `<Description>` field to CLI and Core projects
- Add common properties to new Build.Directory.props file
- Add VS Code configuration files for building and running
- Update documentation for contributing