### PR TITLE
Add nuspec files for .Core and .Cli packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,15 @@ The Template Analyzer solution is comprised of the following main components:
   * BuiltInRules.json (*[src\Analyzer.Core\Rules\BuiltInRules.json](./src/Analyzer.Core/Rules/BuiltInRules.json)*): The file with the built-in Template BPA rules.
 * Template Processor (*[src\Analyzer.TemplateProcessor](./src/Analyzer.TemplateProcessor)*): This library parses ARM templates and evaluates expressions found in the template.
 * JSON Rule Engine (*[src\Analyzer.JsonRuleEngine](./src/Analyzer.JsonRuleEngine)*): The library dedicated to parse and evaluate the Template BPA JSON rules.
+
+### NuGet Packages
+* There are two .nuspec files that define NuGet packages that can be created
+  * [src\Analyzer.Core.NuGet\Analyzer.Core.nuspec](./src/Analyzer.Core.NuGet/Analyzer.Core.nuspec) for packing Analyzer.Core into package *Azure.Templates.Analyzer.Core*.
+  * [src\Analyzer.Cli.NuGet\Analyzer.Cli.nuspec](./src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec) for packing Analyzer.Cli into package *Azure.Templates.Analyzer.CommandLine*.
+* These can be packed (after building the solution) using the [nuget.exe CLI](https://www.nuget.org/downloads)
+  * Example: `nuget pack <nuspec-file> -p Configuration=<Debug|Release>`
+  * Use `Debug` or `Release` depending on the Configuration the solution or projects were built with
+  * This is a great way to test NuGet consumption of local changes
  
 ### Code Structure
 1. Analyzer CLI (or another calling application) identifies JSON files (template and parameter files) and invokes Analyzer.Core.

--- a/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
+++ b/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Azure.Templates.Analyzer.CommandLine</id>
+    <!-- Also update version of dependency below, and in Analyzer.Core nuspec and Directory.Build.props. -->
+    <version>0.0.1-alpha</version>
+    <authors>Microsoft</authors>
+    <description>A command line interface for Azure.Templates.Analyzer.Core - an ARM Template scanner for security misconfiguration and best practices</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/template-analyzer</projectUrl>
+    <tags>arm azure template analyzer scanner deployment</tags>    
+  </metadata>
+
+  <files>
+    <file src="..\Analyzer.Cli\bin\$configuration$\net5.0\publish\**" target="tools/" exclude="**\*.pdb" />
+  </files>
+
+</package>

--- a/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
+++ b/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
@@ -9,7 +9,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/template-analyzer</projectUrl>
-    <tags>arm azure template analyzer scanner deployment</tags>    
+    <tags>arm azure template analyzer scanner deployment security</tags>    
   </metadata>
 
   <files>

--- a/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
+++ b/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Azure.Templates.Analyzer.Core</id>
+    <!-- Also update version in Analyzer.Cli nuspec and Directory.Build.props. -->
+    <version>0.0.1-alpha</version>
+    <authors>Microsoft</authors>
+    <description>ARM Template scanner for security misconfiguration and best practices</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/Azure/template-analyzer</projectUrl>
+    <tags>arm azure template analyzer scanner deployment</tags>
+
+    <dependencies>
+      <dependency id="Azure.Deployments.Core" version="1.0.112" />
+      <dependency id="Azure.Deployments.Expression" version="1.0.112" />
+      <dependency id="Azure.Deployments.Templates" version="1.0.112" />
+      <dependency id="Newtonsoft.Json" version="12.0.3" />
+    </dependencies>
+    
+  </metadata>
+
+  <files>
+    <file src="..\Analyzer.Core\bin\$configuration$\**" target="lib\" exclude="**\*.pdb" />
+  </files>
+
+</package>

--- a/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
+++ b/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
@@ -9,7 +9,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/Azure/template-analyzer</projectUrl>
-    <tags>arm azure template analyzer scanner deployment</tags>
+    <tags>arm azure template analyzer scanner deployment security</tags>
 
     <dependencies>
       <dependency id="Azure.Deployments.Core" version="1.0.112" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <!-- Also update version in nuspec files for Analyzer.Core and Analyzer.Cli. -->
     <Version>0.0.1-alpha</Version>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
- Adding *.nuspec files to Analyzer.Core.NuGet and Analyzer.Cli.NuGet directories
- NuGet packages can be packed with `nuget pack <.nuspec file> -p configuration=release`
  - Must have nuget CLI installed on machine
- Versions have to be kept in sync manually for now.  Will open an issue to combine into a single source.