### PR TITLE
Fix Code Coverage and Cleanup Up Test Projects

### DIFF
--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/Analyzer.JsonRuleEngine.FunctionalTests.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/RuleParsingTests.cs
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/RuleParsingTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Schemas;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTests
@@ -23,6 +22,12 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTe
         {
             this.Operator = @operator;
         }
+    }
+
+    // Mock ILineNumberResolver for use in tests
+    public class MockLineResolver : ILineNumberResolver
+    {
+        public int ResolveLineNumber(string path) => 0;
     }
 
     [TestClass]
@@ -63,7 +68,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTe
                 operatorProperty,
                 jsonValue));
 
-            var leafExpression = leafDefinition.ToExpression(new Mock<ILineNumberResolver>().Object) as LeafExpression;
+            var leafExpression = leafDefinition.ToExpression(new MockLineResolver()) as LeafExpression;
             Assert.IsNotNull(leafExpression);
             Assert.AreEqual(TestPath, leafExpression.Path);
             Assert.AreEqual(TestResourceType, leafExpression.ResourceType);

--- a/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/Analyzer.JsonRuleEngine.UnitTests.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Analyzer.JsonRuleEngine\Analyzer.JsonRuleEngine.csproj" />
-    <ProjectReference Include="..\Analyzer.TemplateProcessor\Analyzer.TemplateProcessor.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Code coverage reporting was broken in the build, incorrectly including coverage of moq.dll in the reported results (reported coverage was around 35% or so).  Removed the reference to Moq in FunctionalTests, and now it's reporting correctly (95.9%).  (I don't know why including Moq in that test project was resulting in bad reporting, since the reporting still works fine having it referenced in Unit Test projects.)

Also removed a reference to the TemplateProcessor project from the JSON Rule Engine UT projects - there's no need for that reference.