### PR TITLE
Use full file path to read built-in rules file

### DIFF
--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine;
 using Microsoft.Azure.Templates.Analyzer.TemplateProcessor;
 using Microsoft.Azure.Templates.Analyzer.Types;
@@ -75,7 +77,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
 
         private static string LoadRules()
         {
-            return System.IO.File.ReadAllText("Rules/BuiltInRules.json");
+            return System.IO.File.ReadAllText(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/Rules/BuiltInRules.json");
         }
     }
 }


### PR DESCRIPTION
Closes #110 

Now the executable can be run from any directory. We don't want to scan the working directory now for new rules as the issue suggests, further design is needed to support custom rule files