### PR TITLE
Fix copy resources line number mapping bug

### DIFF
--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
             var armTemplateProcessor = new ArmTemplateProcessor(Template);
 
             try
-            {   
+            {
                 templatejObject = armTemplateProcessor.ProcessTemplate(Parameters);
             }
             catch (Exception e)

--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -44,11 +44,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
         public IEnumerable<IEvaluation> EvaluateRulesAgainstTemplate()
         {
             JToken templatejObject;
-            ArmTemplateProcessor armTemplateProcessor;
+            var armTemplateProcessor = new ArmTemplateProcessor(Template);
 
             try
-            {
-                armTemplateProcessor = new ArmTemplateProcessor(Template);
+            {   
                 templatejObject = armTemplateProcessor.ProcessTemplate(Parameters);
             }
             catch (Exception e)

--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -37,10 +37,11 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
         public IEnumerable<IEvaluation> EvaluateRulesAgainstTemplate()
         {
             JToken templatejObject;
+            ArmTemplateProcessor armTemplateProcessor;
 
             try
             {
-                ArmTemplateProcessor armTemplateProcessor = new ArmTemplateProcessor(Template);
+                armTemplateProcessor = new ArmTemplateProcessor(Template);
                 templatejObject = armTemplateProcessor.ProcessTemplate(Parameters);
             }
             catch (Exception e)
@@ -62,7 +63,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
                     new TemplateContext {
                         OriginalTemplate = JObject.Parse(Template),
                         ExpandedTemplate = templatejObject,
-                        IsMainTemplate = true },
+                        IsMainTemplate = true,
+                        ResourceMappings = armTemplateProcessor.ResourceMappings },
                     rules);
 
                 return evaluations;

--- a/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
+++ b/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
@@ -515,6 +515,13 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
                 ""dependsOn"": [ ""someResource"" ],
                 ""properties"": { }
             }", DisplayName = "Child resource depends on resource outside template scope")]
+        [DataRow(@"{
+                ""type"": ""Microsoft.Network/networkInterfaces"",
+                ""apiVersion"": ""2018-10-01"",
+                ""name"": ""simpleLinuxVMNetInt"",
+                ""location"": ""westus"",
+                ""properties"": { }
+            }", DisplayName = "Child resource depends on not specified")]
         public void CopyResourceDependants_ChildDependsOnEmptyOrResourceNotInCurrentTemplate_NoResourcesWereChanged(string templateResource0Json)
         {
             // Arrange
@@ -540,8 +547,12 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
             // Assert
             var actualResourceArray = template.InsensitiveToken("resources");
 
-            string expectedResourceArray = $"[ {templateResource0Json}, {templateResource1Json} ]";
-            var expectedResourceJArray = JArray.Parse(expectedResourceArray);
+            JObject expectedResource0 = JObject.Parse(templateResource0Json);
+            JObject expectedResource1 = JObject.Parse(templateResource1Json);
+
+            expectedResource0.AddIfNotExists("dependsOn", new JArray());
+
+            var expectedResourceJArray = new JArray { expectedResource0, expectedResource1 };
 
             Assert.IsTrue(JToken.DeepEquals(expectedResourceJArray, actualResourceArray));
 

--- a/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
+++ b/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
@@ -350,7 +350,16 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
                         ""apiVersion"": ""2019-04-01"",
                         ""name"": ""embeddedChildVnet"",
                         ""location"": ""westus"",
-                        ""properties"": { }
+                        ""properties"": { },
+                        ""resources"": [
+                            {
+                                ""type"": ""Microsoft.Network/virtualNetworks"",
+                                ""apiVersion"": ""2019-04-01"",
+                                ""name"": ""embeddedGrandChildVnet"",
+                                ""location"": ""westus"",
+                                ""properties"": { }
+                            }
+                        ],
                     }
                 ],
                 ""properties"": { }
@@ -371,6 +380,7 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
                 { "resources[2].resources[0]", "resources[0]" },
                 { "resources[3]", "resources[3]" },
                 { "resources[3].resources[0]", "resources[3].resources[0]" },
+                { "resources[3].resources[0].resources[0]", "resources[3].resources[0].resources[0]" },
                 { "resources[3].resources[1]", "resources[0]" }
             };
 

--- a/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
+++ b/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
@@ -334,18 +334,6 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
             Template template = armTemplateProcessor.ParseAndValidateTemplate(parameters, metadata);
 
             Assert.AreEqual(expectedMapping.Count, template.Resources.Length);
-
-            // First resource should be the resource without a copy index specified
-            Assert.AreEqual("resourceWith/NoCopyLoop", template.Resources.First().Name.Value);
-
-            Assert.AreEqual("name/SSH-VMNamePrefix-1", template.Resources[2].Name.Value);
-            Assert.AreEqual("[concat('name', '/', 'SSH-', 'VMNamePrefix-', copyIndex())]", template.Resources[2].OriginalName);
-            Assert.AreEqual(2201, template.Resources[2].Properties.Value.InsensitiveToken("frontendPort").Value<int>());
-
-            Assert.AreEqual("name/CopyLoop2-SSH-VMNamePrefix-1", template.Resources.Last().Name.Value);
-            Assert.AreEqual("[concat('name', '/', 'CopyLoop2-SSH-', 'VMNamePrefix-', copyIndex())]", template.Resources.Last().OriginalName);
-            Assert.AreEqual(2201, template.Resources.Last().Properties.Value.InsensitiveToken("frontendPort").Value<int>());
-
             AssertDictionariesAreEqual(expectedMapping, armTemplateProcessor.ResourceMappings);
         }
 

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -399,25 +399,20 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
             for (int i = 0; i < template.Resources.Length; i++)
             {
                 var resource = template.Resources[i];
-                if (resource.Copy != null)
+                if (resource.Copy != null && copyNameMap.TryGetValue(resource.Copy.Name.Value, out (string, int) originalValues))
                 {
                     // Copied resource.  Update OriginalName and
                     // add mapping to original resource
-                    if (copyNameMap.TryGetValue(resource.Copy.Name.Value, out (string, int) originalValues))
-                    {
-                        resource.OriginalName = originalValues.Item1;
+                    resource.OriginalName = originalValues.Item1;
 
-                        resource.Path = $"resources[{i}]";
-                        AddResourceMapping(resource.Path, $"resources[{originalValues.Item2}]");
+                    resource.Path = $"resources[{i}]";
+                    AddResourceMapping(resource.Path, $"resources[{originalValues.Item2}]");
 
-                        continue;
-                    }
+                    continue;
                 }
                     
                 AddResourceMapping($"resources[{i}]", resource.Path);
             }
-            
-            return;
         }
 
         /// <summary>

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -260,14 +260,14 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
 
             for (int i = 0; i < tokens.Length - 1; i++)
             {
-                string subPath = string.Join('.', tokens[..(i + 1)]);
-                if (originalToExpandedMapping.ContainsKey(subPath))
+                string possibleOriginalPathOfAnotherResource = string.Join('.', tokens[..(i + 1)]);
+                if (originalToExpandedMapping.TryGetValue(possibleOriginalPathOfAnotherResource, out List<string> copiedLocationsOfAnotherResource))
                 {
-                    foreach (string path in originalToExpandedMapping[subPath])
+                    foreach (string copiedLocationOfAnotherResource in copiedLocationsOfAnotherResource)
                     {
-                        if (!path.Equals(subPath, StringComparison.OrdinalIgnoreCase))
+                        if (!copiedLocationOfAnotherResource.Equals(possibleOriginalPathOfAnotherResource, StringComparison.OrdinalIgnoreCase))
                         {
-                            ResourceMappings.TryAdd($"{path}.{string.Join('.', tokens[(i + 1)..])}", originalTemplatePath);
+                            ResourceMappings.TryAdd($"{copiedLocationOfAnotherResource}.{string.Join('.', tokens[(i + 1)..])}", originalTemplatePath);
                         }
                     }
                 }

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
                 // Do not throw if there was an issue with evaluating language expressions
             }
 
-            MapResources(template, copyNameMap);
+            MapTopLevelResources(template, copyNameMap);
 
             TemplateEngine.ValidateProcessedTemplate(template, apiVersion, TemplateDeploymentScope.NotSpecified);
 
@@ -392,17 +392,17 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
         /// </summary>
         /// <param name="template">The template</param>
         /// <param name="copyNameMap">Mapping of the copy name, the original name of the resource, and index of resource in resource list.</param>
-        private void MapResources(Template template, Dictionary<string, (string, int)> copyNameMap)
+        private void MapTopLevelResources(Template template, Dictionary<string, (string, int)> copyNameMap)
         {
-            // Set OriginalName back on resources that were copied and map them
-            // to their original resource
+            // Set OriginalName back on resources that were copied
+            // and map them to their original resource
             for (int i = 0; i < template.Resources.Length; i++)
             {
                 var resource = template.Resources[i];
                 if (resource.Copy != null)
                 {
                     // Copied resource.  Update OriginalName and
-                    // add maping to original resource
+                    // add mapping to original resource
                     if (copyNameMap.TryGetValue(resource.Copy.Name.Value, out (string, int) originalValues))
                     {
                         resource.OriginalName = originalValues.Item1;
@@ -413,10 +413,8 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
                         continue;
                     }
                 }
-                else
-                {
-                    AddResourceMapping($"resources[{i}]", resource.Path);
-                }
+                    
+                AddResourceMapping($"resources[{i}]", resource.Path);
             }
             
             return;

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -314,7 +314,10 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
 
                 if (resource.Resources != null)
                 {
-                    SaveFlattenedResources(resource.Resources, resource.Name.Value, resource.Type.Value);
+                    string resourceNamePrefix = parentName == null ? "" : $"{parentName}/";
+                    string resourceTypePrefix = parentType == null ? "" : $"{parentType}/";
+
+                    SaveFlattenedResources(resource.Resources, $"{resourceNamePrefix}{resource.Name.Value}", $"{resourceTypePrefix}{resource.Type.Value}");
                 }
             }
         }

--- a/src/Analyzer.Types/TemplateContext.cs
+++ b/src/Analyzer.Types/TemplateContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Templates.Analyzer.Types
@@ -29,5 +30,13 @@ namespace Microsoft.Azure.Templates.Analyzer.Types
         /// Whether this template is the top-level template in a deployment or nested within another template
         /// </summary>
         public bool IsMainTemplate { get; set; }
+
+        /// <summary>
+        /// Mapping between resources in the expanded template to their original resource in 
+        /// the original template. Used to get line numbers.
+        /// The key is the path in the expanded template with value being the path
+        /// in the original template.
+        /// </summary>
+        public Dictionary<string, string> ResourceMappings { get; set; }
     }
 }

--- a/src/Analyzer.Utilities.UnitTests/JsonLineNumberResolverTests.cs
+++ b/src/Analyzer.Utilities.UnitTests/JsonLineNumberResolverTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
                         },
                         ""copy"": {
                             ""name"": ""copyLoop"",
-                            ""count"": 3
+                            ""count"": 2
                         },
                         ""anExpandedProperty"": ""anExpandedValue""
                     },
@@ -171,41 +171,35 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
                         },
                         ""copy"": {
                             ""name"": ""copyLoop"",
-                            ""count"": 3
+                            ""count"": 2
                         }
                     },
                     {
                         ""type"": ""Microsoft.ResourceProvider/badResource"",
                         ""copy"": {
                             ""name"": ""missingSourceCopyInOriginal"",
-                            ""count"": 3
+                            ""count"": 2
                         }
                     },
                     {
                         ""type"": ""Microsoft.ResourceProvider/ExtraResourceInExpandedTemplate"",
-                    },
-                    {
-                        ""name"": ""resource7""
-                    },
-                    {
-                        ""name"": ""resource8""
-                    },
-                    {
-                        ""name"": ""resource9""
-                    },
-                    {
-                        ""type"": ""Microsoft.ResourceProvider/resource0"",
-                        ""properties"": {
-                            ""somePath"": ""someValue"",
-                            ""anotherProperty"": true
-                        },
-                        ""copy"": {
-                            ""name"": ""copyLoop"",
-                            ""count"": 3
-                        }
                     }
                 ]
-            }")
+            }"),
+
+            ResourceMappings = new Dictionary<string, string>
+            {
+                { "resources[0]", "resources[0]" },
+                { "resources[1]", "resources[1]" },
+                { "resources[1].resources[0]", "resources[2]" },
+                { "resources[1].resources[0].resources[0]", "resources[2].resources[0]" },
+                { "resources[1].resources[0].resources[1]", "resources[3]" },
+                { "resources[2]", "resources[2]" },
+                { "resources[2].resources[0]", "resources[2].resources[0]" },
+                { "resources[2].resources[1]", "resources[3]" },
+                { "resources[3]", "resources[3]" },
+                { "resources[4]", "resources[0]" }
+            }
         };
 
         #endregion
@@ -226,8 +220,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
             new object[] { "resources[1].resources[0].resources[1].properties.somePath", new object[] { "resources", 3, "properties", "somePath" }, "Path goes to a resource that's been copied into another resource as a grandchild" },
             new object[] { "resources[1].resources[0].resources[0].properties.somePath", new object[] { "resources", 2, "resources", 0, "properties", "somePath" }, "Path goes to a resource that's been copied but was still originally a child resource" },
             new object[] { "resources[1].resources[0].dependsOn[1]", new object[] { "resources", 2, "dependsOn" }, "Path goes to a property not specified in original template in a copied resource that is also an array" },
-            new object[] { "resources[2].dependsOn[1]", new object[] { "resources", 2, "dependsOn" }, "Path goes to a property not specified in original template in a non-copied resource that is also an array" },
-            new object[] { "resources[10].properties.somePath", new object[] { "resources", 0, "properties", "somePath" }, "Path is in a copied resource where copied index digit length is greater than original resource" }
+            new object[] { "resources[2].dependsOn[1]", new object[] { "resources", 2, "dependsOn" }, "Path goes to a property not specified in original template in a non-copied resource that is also an array" }
         }.AsReadOnly();
 
         // Just returns the element in the last index of the array from TestScenarios
@@ -259,7 +252,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
         public void ResolveLineNumber_UnableToFindEquivalentLocationInOriginal_Returns0(string path)
         {
             Assert.AreEqual(
-                0,
+                1,
                 new JsonLineNumberResolver(templateContext)
                 .ResolveLineNumber(path));
         }

--- a/src/Analyzer.Utilities.UnitTests/JsonLineNumberResolverTests.cs
+++ b/src/Analyzer.Utilities.UnitTests/JsonLineNumberResolverTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities.UnitTests
         [DataRow("MissingFirstChild.any.other.path", DisplayName = "First child in path not found")]
         [DataRow("resources[6].type", DisplayName = "Extra resource")]
         [DataRow("resources[5].type", DisplayName = "Extra copied resource with missing source copy loop")]
-        public void ResolveLineNumber_UnableToFindEquivalentLocationInOriginal_Returns0(string path)
+        public void ResolveLineNumber_UnableToFindEquivalentLocationInOriginal_Returns1(string path)
         {
             Assert.AreEqual(
                 1,

--- a/src/Analyzer.Utilities/JsonLineNumberResolver.cs
+++ b/src/Analyzer.Utilities/JsonLineNumberResolver.cs
@@ -79,12 +79,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
                     return 1;
                 }
 
-                if (string.Equals(resourceWithIndex, originalResourcePath))
+                if (!string.Equals(resourceWithIndex, originalResourcePath))
                 {
-                    return (tokenFromOriginalTemplate as IJsonLineInfo)?.LineNumber ?? 1;
+                    return ResolveLineNumber($"{originalResourcePath}.{remainingPathAtResourceScope}");
                 }
-
-                return ResolveLineNumber($"{originalResourcePath}.{remainingPathAtResourceScope}");
             }
 
             return (tokenFromOriginalTemplate as IJsonLineInfo)?.LineNumber ?? 1;

--- a/src/Analyzer.Utilities/JsonLineNumberResolver.cs
+++ b/src/Analyzer.Utilities/JsonLineNumberResolver.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
         {
             JToken expandedTemplateRoot = this.templateContext.ExpandedTemplate;
             JToken originalTemplateRoot = this.templateContext.OriginalTemplate;
-            Match match;
 
             if (pathInExpandedTemplate == null || originalTemplateRoot == null)
             {
@@ -56,89 +55,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
             // even the first property could not be found in the original template.
             if (tokenFromOriginalTemplate.Equals(originalTemplateRoot))
             {
-                return 0;
+                return 1;
             }
 
-            // If the JToken returned from looking up the expanded template path is
-            // pointing to the resources array of the original template, then it's likely
-            // the expanded template path used an index too large for the original template.
-            if (tokenFromOriginalTemplate.Equals(originalTemplateRoot.InsensitiveToken("resources")))
-            {
-                // Verify the path starts with indexing into the template resources[] array
-                match = resourceIndexInPath.Match(pathInExpandedTemplate);
-                if (match.Success)
-                {
-                    // Verify the expanded template is available.
-                    // (Avoid throwing earlier since this is not always needed.)
-                    if (expandedTemplateRoot == null)
-                    {
-                        throw new ArgumentNullException(nameof(expandedTemplateRoot));
-                    }
-
-                    // The first property is a resource, likely with a larger index
-                    // than the number of resources in the original template.
-                    // See if the requested resource is a copied resource.
-                    var resourceWithIndex = match.Value;
-                    var parsedResource = expandedTemplateRoot.InsensitiveToken($"{resourceWithIndex}.copy.name", InsensitivePathNotFoundBehavior.Null);
-                    if (parsedResource != null)
-                    {
-                        // Find the resource with this copy name in the original template
-                        bool foundResourceCopySource = false;
-                        var copyName = parsedResource.Value<string>();
-                        foreach (var resource in originalTemplateRoot.InsensitiveToken("resources").Children())
-                        {
-                            var thisResourceCopyName = resource.InsensitiveToken("copy.name")?.Value<string>();
-                            if (string.Equals(copyName, thisResourceCopyName))
-                            {
-                                // This is the original resource for the expanded copy.
-                                // Replace the index in the path with the index of the source copy.
-                                pathInExpandedTemplate = resourceIndexInPath.Replace(pathInExpandedTemplate, resource.Path);
-                                tokenFromOriginalTemplate = originalTemplateRoot.InsensitiveToken(pathInExpandedTemplate, InsensitivePathNotFoundBehavior.LastValid);
-                                foundResourceCopySource = true;
-                                break;
-                            }
-                        }
-
-                        if (!foundResourceCopySource)
-                        {
-                            // Unknown issue - there's a copied resource without a matching original copy
-                            return 0;
-                        }
-                    }
-                    else
-                    {
-                        // Unknown issue - there's an extra resource that didn't come from a copy loop
-                        return 0;
-                    }
-                }
-            }
-
-            var originalTemplatePath = tokenFromOriginalTemplate.Path;
-            var unmatchedPathInOriginalTemplate = pathInExpandedTemplate[originalTemplatePath.Length..].TrimStart('.');
-
-            bool pathsAreEqual = string.Equals(originalTemplatePath, pathInExpandedTemplate, StringComparison.OrdinalIgnoreCase);
-
-            bool unmatchedSegmentReferencesResourcesArray = unmatchedPathInOriginalTemplate.StartsWith("resources", StringComparison.OrdinalIgnoreCase);
-            bool unmatchedSegmentStartsWithIndexArray = unmatchedPathInOriginalTemplate.StartsWith("[", StringComparison.OrdinalIgnoreCase);
-            bool indexExpectedIsInResourcesArray = originalTemplatePath.EndsWith("resources", StringComparison.OrdinalIgnoreCase);
-
-            bool pathIsFromCopiedResource = unmatchedSegmentReferencesResourcesArray
-                    || (unmatchedSegmentStartsWithIndexArray
-                    && indexExpectedIsInResourcesArray);
-
-            // Compare the path of the expanded template with the path of the JToken found in the original template.
-            // If they match or if the path is not from a copied resource
-            // the line number from the JToken of the original template can be returned directly.
-            if (pathsAreEqual || !pathIsFromCopiedResource)
-            {
-                return (tokenFromOriginalTemplate as IJsonLineInfo)?.LineNumber ?? 0;
-            }
-
-            // The first unmatched property must be a resources[] array, likely a subresource
-            // of a top-level resource.  This is possible if resources were copied into other
-            // resources as part of template expansion.
-
-            // Get the line number of the original resource before it was copied
+            // If the path is in the resources array of the template
             var matches = resourceIndexInPath.Matches(pathInExpandedTemplate);
             if (matches.Count > 0)
             {
@@ -154,62 +74,20 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
 
                 string remainingPathAtResourceScope = pathInExpandedTemplate[(resourceWithIndex.Length + 1)..];
 
-                // Get the resource name and type from the expanded template
-                var childResourceName = expandedTemplateRoot.InsensitiveToken($"{resourceWithIndex}.name", InsensitivePathNotFoundBehavior.Null);
-                var childResourceType = expandedTemplateRoot.InsensitiveToken($"{resourceWithIndex}.type", InsensitivePathNotFoundBehavior.Null);
-                if (childResourceName != null && childResourceType != null)
+                if (!templateContext.ResourceMappings.TryGetValue(resourceWithIndex, out string originalResourcePath))
                 {
-                    var childName = childResourceName.Value<string>();
-                    var childType = childResourceType.Value<string>();
-
-                    // Find the resource with this name and type in the expanded template
-                    string resourcePathInOriginalTemplate = GetResourcePath(originalTemplateRoot.InsensitiveToken("resources", InsensitivePathNotFoundBehavior.Null), childName, childType);
-                    
-                    return ResolveLineNumber($"{resourcePathInOriginalTemplate}.{remainingPathAtResourceScope}");
-                }
-            }
-
-            // If code returns here, it is an unexpected case
-            return 1;
-        }
-
-        /// <summary>
-        /// Given a list of resources, resource name, and resource type, return the JSON path of that resource.
-        /// </summary>
-        /// <param name="resources">JArray of resources.</param>
-        /// <param name="resourceName">Name of resource.</param>
-        /// <param name="resourceType">Type of resource.</param>
-        /// <returns>The JSON path where the resource is located.</returns>
-        private string GetResourcePath(JToken resources, string resourceName, string resourceType)
-        {
-            if (resources == null)
-            {
-                return null;
-            }
-
-            foreach (var resource in resources.Children())
-            {
-                var thisResourceName = resource.InsensitiveToken("name")?.Value<string>();
-                var thisResourceType = resource.InsensitiveToken("type")?.Value<string>();
-                if (string.Equals(resourceType, thisResourceType, StringComparison.OrdinalIgnoreCase) && string.Equals(resourceName, thisResourceName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return resource.Path;
+                    return 1;
                 }
 
-                var childResources = resource.InsensitiveToken("resources", InsensitivePathNotFoundBehavior.Null);
-
-                if (childResources != null)
+                if (string.Equals(resourceWithIndex, originalResourcePath))
                 {
-                    string path = GetResourcePath(childResources, resourceName, resourceType);
-                    
-                    if (path != null)
-                    {
-                        return path;
-                    }
+                    return (tokenFromOriginalTemplate as IJsonLineInfo)?.LineNumber ?? 1;
                 }
+
+                return ResolveLineNumber($"{originalResourcePath}.{remainingPathAtResourceScope}");
             }
 
-            return null;
+            return (tokenFromOriginalTemplate as IJsonLineInfo)?.LineNumber ?? 1;
         }
     }
 }


### PR DESCRIPTION
- Makes and uses mapping between resources in expanded template to original template for easier line number mapping (Closes #125)
- Processes all resources language expressions once flattened