### PR TITLE
Remove unimplemented commands

### DIFF
--- a/src/Analyzer.Cli/CommandLineParser.cs
+++ b/src/Analyzer.Cli/CommandLineParser.cs
@@ -41,10 +41,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             rootCommand = new RootCommand();
             rootCommand.Description = "Analyze Azure Resource Manager (ARM) Templates for security and best practice issues.";
 
-            // It has two commands - analyze-template and analyze-directory
             rootCommand.AddCommand(SetupAnalyzeTemplateCommand());
-
-            rootCommand.AddCommand(SetupAnalyzeDirectoryCommand());
             
             return rootCommand;
         }
@@ -70,8 +67,6 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             parameterOption.AddAlias("-p");
 
             analyzeTemplateCommand.AddOption(parameterOption);
-
-            analyzeTemplateCommand.AddOption(SetupOutputFileOption());
 
             analyzeTemplateCommand.Handler = CommandHandler.Create<FileInfo, FileInfo>((templateFilePath, parametersFilePath) =>
             {
@@ -137,49 +132,6 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             }
 
             return resultString;
-        }
-
-        private Command SetupAnalyzeDirectoryCommand()
-        {
-            // Setup analyze-directory 
-            Command analyzeDirectoryCommand = new Command("analyze-directory");
-
-            Option<DirectoryInfo> directoryOption = new Option<DirectoryInfo>(
-                    "--directory-path",
-                    "Directory to search for ARM templates (.json file extension)")
-            {
-                IsRequired = true
-            };
-            directoryOption.AddAlias("-d");
-
-            analyzeDirectoryCommand.AddOption(directoryOption);
-
-            Option<bool> recursiveOption = new Option<bool>(
-                    "--recursive",
-                    "Search directory and all subdirectories");
-            recursiveOption.AddAlias("-r");
-
-            analyzeDirectoryCommand.AddOption(recursiveOption);
-
-            analyzeDirectoryCommand.AddOption(SetupOutputFileOption());
-
-            analyzeDirectoryCommand.Handler = CommandHandler.Create<DirectoryInfo, bool>((directoryPath, recursive) =>
-            {
-                // TODO: This needs to call the library and pass in a list of templates
-            });
-
-            return analyzeDirectoryCommand;
-        }
-
-        private Option SetupOutputFileOption()
-        {
-            Option<FileInfo> outputFileOption = new Option<FileInfo>(
-                        "--output-path",
-                        "Redirect output to specified file in JSON format");
-
-            outputFileOption.AddAlias("-o");
-
-            return outputFileOption;
         }
     }
 }


### PR DESCRIPTION
Remove unimplemented commands from the CLI because showing some of those options in "--help" generates confusion