### PR TITLE
Make AnyOf not fail if nothing is evaluated

### DIFF
--- a/src/Analyzer.JsonRuleEngine.UnitTests/AllOfExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/AllOfExpressionTests.cs
@@ -97,70 +97,57 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             }
         }
 
-        [TestMethod]
-        public void Evaluate_SubResourceScopeNotFound_ExpectedResultIsReturned()
+        [DataTestMethod]
+        [DataRow(null, true, true, DisplayName = "First expression not evaluated, second expression passes, overall result is pass")]
+        [DataRow(null, false, false, DisplayName = "First expression not evaluated, second expression fails, overall result is fail")]
+        [DataRow(true, null, true, DisplayName = "First expression passes, second expression not evaluated, overall result is pass")]
+        [DataRow(null, null, true, DisplayName = "All expressions not evaluated, overall result is pass")]
+        public void Evaluate_SubResourceScopeNotFound_ExpectedResultIsReturned(bool? firstExpressionPass, bool? secondExpressionPass, bool overallPass)
         {
+            string evaluatedPath = "some.evaluated.path";
+            string notEvaluatedPath = "path.not.evaluated";
+
             // Arrange
             var mockJsonPathResolver = new Mock<IJsonPathResolver>();
             mockJsonPathResolver
-                .Setup(r => r.Resolve(It.IsAny<string>()))
+                .Setup(r => r.Resolve(It.Is<string>(path => evaluatedPath.Equals(path))))
                 .Returns(() => new[] { mockJsonPathResolver.Object });
-            mockJsonPathResolver
-                .Setup(r => r.ResolveResourceType(It.IsAny<string>()))
-                .Returns(() => new[] { mockJsonPathResolver.Object });
-
-            // Create a mock expression for the Where condition.
-            // It will return an Evaluation that has no results, but Passed is true.
-            var whereExpression = new MockExpression(new ExpressionCommonProperties())
-            {
-                // This will only be executed if this where condition is evaluated.
-                EvaluationCallback = pathResolver =>
-                {
-                    return new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>());
-                }
-            };
 
             var mockLineResolver = new Mock<ILineNumberResolver>().Object;
 
-            // This AnyOf will have 2 expressions
-            // A top level mocked expression that contains a Where condition.
-            var mockLeafExpression1 = new MockExpression(new ExpressionCommonProperties { ResourceType = "ResourceProvider/resource", Path = "some.path", Where = whereExpression })
-            {
-                // This will only be executed if the expression is evaluated.
-                EvaluationCallback = pathResolver =>
-                {
-                    return null;
-                }
-            };
-            var mockOperator2 = new Mock<LeafExpressionOperator>().Object;
+            // Create 2 expressions for the AnyOf.
+            // Whether each is evaluated or not is determined by the path passed to each.
 
-            var mockLeafExpression2 = new Mock<LeafExpression>(mockLineResolver, mockOperator2, new ExpressionCommonProperties { ResourceType = "ResourceProvider/resource", Path = "some.path" });
-
-            var jsonRuleResult2 = new JsonRuleResult
+            var mockLeafExpression1 = new MockExpression(new ExpressionCommonProperties { Path = firstExpressionPass.HasValue ? evaluatedPath : notEvaluatedPath })
             {
-                Passed = false
+                EvaluationCallback = pathResolver => firstExpressionPass.HasValue
+                        ? new JsonRuleEvaluation(null, firstExpressionPass.Value, new[] { new JsonRuleResult { Passed = firstExpressionPass.Value } })
+                        : null
             };
 
-            var results2 = new JsonRuleResult[] { jsonRuleResult2 };
+            var mockLeafExpression2 = new MockExpression(new ExpressionCommonProperties { Path = secondExpressionPass.HasValue ? evaluatedPath : notEvaluatedPath })
+            {
+                EvaluationCallback = pathResolver => secondExpressionPass.HasValue
+                        ? new JsonRuleEvaluation(null, secondExpressionPass.Value, new[] { new JsonRuleResult { Passed = secondExpressionPass.Value } })
+                        : null
+            };
 
-            mockLeafExpression2
-                .Setup(s => s.Evaluate(mockJsonPathResolver.Object))
-                .Returns(new JsonRuleEvaluation(mockLeafExpression2.Object, false, results2));
+            var allOfExpression = new AllOfExpression(
+                new Expression[] { mockLeafExpression1, mockLeafExpression2 },
+                new ExpressionCommonProperties());
 
-            var expressionArray = new Expression[] { mockLeafExpression1, mockLeafExpression2.Object };
-
-            var allOfExpression = new AllOfExpression(expressionArray, new ExpressionCommonProperties());
+            var expectedResults = new[] { firstExpressionPass, secondExpressionPass };
 
             // Act
             var allOfEvaluation = allOfExpression.Evaluate(mockJsonPathResolver.Object);
 
             // Assert
-            Assert.AreEqual(false, allOfEvaluation.Passed);
-            Assert.AreEqual(1, allOfEvaluation.Evaluations.Count());
-            Assert.IsTrue(allOfEvaluation.HasResults);
+            Assert.AreEqual(overallPass, allOfEvaluation.Passed);
+            Assert.AreEqual(expectedResults.Count(r => r.HasValue), allOfEvaluation.Evaluations.Count());
+            Assert.AreEqual(expectedResults.Any(r => r.HasValue), allOfEvaluation.HasResults);
 
-            Assert.AreEqual(0, allOfEvaluation.EvaluationsEvaluatedTrue.Count());
-            Assert.AreEqual(1, allOfEvaluation.EvaluationsEvaluatedFalse.Count());
+            Assert.AreEqual(expectedResults.Count(r => r.HasValue && r.Value), allOfEvaluation.EvaluationsEvaluatedTrue.Count());
+            Assert.AreEqual(expectedResults.Count(r => r.HasValue && !r.Value), allOfEvaluation.EvaluationsEvaluatedFalse.Count());
         }
 
         [TestMethod]

--- a/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
             return EvaluateInternal(jsonScope, scope =>
             {
                 List<JsonRuleEvaluation> jsonRuleEvaluations = new List<JsonRuleEvaluation>();
-                bool evaluationPassed = false;
 
                 foreach (var expression in AnyOf)
                 {
@@ -48,11 +47,10 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
                     // Add evaluations if scopes were found to evaluate
                     if (evaluation.HasResults)
                     {
-                        evaluationPassed |= evaluation.Passed;
                         jsonRuleEvaluations.Add(evaluation);
                     }
                 }
-
+                bool evaluationPassed = jsonRuleEvaluations.Count == 0 || !jsonRuleEvaluations.TrueForAll(e => !e.Passed);
                 return new JsonRuleEvaluation(this, evaluationPassed, jsonRuleEvaluations);
             });
         }

--- a/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
                         jsonRuleEvaluations.Add(evaluation);
                     }
                 }
-                bool evaluationPassed = jsonRuleEvaluations.Count == 0 || jsonRuleEvaluations.Any(e => e.Passed);
+                bool evaluationPassed = jsonRuleEvaluations.Count == 0 || jsonRuleEvaluations.Exists(e => e.Passed);
                 return new JsonRuleEvaluation(this, evaluationPassed, jsonRuleEvaluations);
             });
         }

--- a/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/AnyOfExpression.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
                         jsonRuleEvaluations.Add(evaluation);
                     }
                 }
-                bool evaluationPassed = jsonRuleEvaluations.Count == 0 || !jsonRuleEvaluations.TrueForAll(e => !e.Passed);
+                bool evaluationPassed = jsonRuleEvaluations.Count == 0 || jsonRuleEvaluations.Any(e => e.Passed);
                 return new JsonRuleEvaluation(this, evaluationPassed, jsonRuleEvaluations);
             });
         }


### PR DESCRIPTION
Updates AnyOf operator to only fail if something was evaluated and something internal failed.  Otherwise, if nothing is evaluated, pass by default.  This ensures rules in which no paths/resource types are relevant inside an AnyOf don't result in a failure.  Closes #138.

- Update AnyOf with bug fix
- Update corresponding test for AnyOf and AllOf