### PR TITLE
Generalize XML comment enforcement

### DIFF
--- a/src/Analyzer.Cli/Analyzer.Cli.csproj
+++ b/src/Analyzer.Cli/Analyzer.Cli.csproj
@@ -7,12 +7,6 @@
     <Description>A command line interface for Microsoft.Azure.Templates.Analyzer.Core - an ARM template scanner for security misconfigurations and best practices</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
-    <DocumentationFile>bin\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>

--- a/src/Analyzer.Core/Analyzer.Core.csproj
+++ b/src/Analyzer.Core/Analyzer.Core.csproj
@@ -7,11 +7,6 @@
     <Description>An ARM template scanner for security misconfigurations and best practices</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Analyzer.Core.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Analyzer.JsonRuleEngine\Analyzer.JsonRuleEngine.csproj" />
     <ProjectReference Include="..\Analyzer.PowerShellRuleEngine\Analyzer.PowerShellRuleEngine.csproj" />

--- a/src/Analyzer.JsonRuleEngine/Analyzer.JsonRuleEngine.csproj
+++ b/src/Analyzer.JsonRuleEngine/Analyzer.JsonRuleEngine.csproj
@@ -5,11 +5,6 @@
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.JsonRuleEngine</AssemblyName>
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine</RootNamespace>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Analyzer.Utilities.xml</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Analyzer.PowerShellRuleEngine/Analyzer.PowerShellRuleEngine.csproj
+++ b/src/Analyzer.PowerShellRuleEngine/Analyzer.PowerShellRuleEngine.csproj
@@ -5,11 +5,6 @@
     <AssemblyName>Microsoft.Azure.Templates.Analyzer.PowerShellRuleEngine</AssemblyName>
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine</RootNamespace>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Analyzer.PowerShellRuleEngine.xml</DocumentationFile>
-  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />

--- a/src/Analyzer.TemplateProcessor/Analyzer.TemplateProcessor.csproj
+++ b/src/Analyzer.TemplateProcessor/Analyzer.TemplateProcessor.csproj
@@ -6,11 +6,6 @@
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.TemplateProcessor</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Analyzer.TemplateProcessor.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Azure.Deployments.Core" Version="1.0.112" />
     <PackageReference Include="Azure.Deployments.Expression" Version="1.0.112" />

--- a/src/Analyzer.Types/Analyzer.Types.csproj
+++ b/src/Analyzer.Types/Analyzer.Types.csproj
@@ -6,11 +6,6 @@
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.Types</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Analyzer.Types.xml</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/src/Analyzer.Utilities/Analyzer.Utilities.csproj
+++ b/src/Analyzer.Utilities/Analyzer.Utilities.csproj
@@ -6,11 +6,6 @@
     <RootNamespace>Microsoft.Azure.Templates.Analyzer.Utilities</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Analyzer.Utilities.xml</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <!-- Defined in .targets file because $(Configuration) and $(Platform) aren't yet defined when Directory.Build.props is imported and evaluated. -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU' And !$(MSBuildProjectName.EndsWith('Tests'))">
+    <DocumentationFile>bin\$(AssemblyName).xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Putting property group that generates code documentation (and enforces XML comments) into common *Directory.Build.targets* file
  - Only applies to projects that aren't tests
- Removing from all projects that declared them manually