### PR TITLE
Output TTK with Analyzer.Core build and fix 'dotnet publish' for debug builds

### DIFF
--- a/src/Analyzer.Core/Analyzer.Core.csproj
+++ b/src/Analyzer.Core/Analyzer.Core.csproj
@@ -20,4 +20,6 @@
     </None>
   </ItemGroup>
 
+  <Import Project="..\TTK.targets" />
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <!-- Defined in .targets file because $(Configuration) and $(Platform) aren't yet defined when Directory.Build.props is imported and evaluated. -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU' And !$(MSBuildProjectName.EndsWith('Tests'))">
-    <DocumentationFile>bin\$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Output TTK with build of Analyzer.Core (closes #154)
  - Allows TTK to be included in NuGet package of just the core library
- Update output location of code documentation file (closes #155)