### PR TITLE
Throw exceptions about incorrect segment lengths and related rule improvement

### DIFF
--- a/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
+++ b/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
@@ -17,7 +17,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "state": "Enabled",
@@ -41,7 +41,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": false,
@@ -61,7 +61,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": false,
@@ -81,7 +81,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": false,
@@ -101,7 +101,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": true,
@@ -121,7 +121,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": true,
@@ -140,7 +140,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": false,
@@ -160,7 +160,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "default",
           "properties": {
             "isAzureMonitorTargetEnabled": false,
@@ -180,7 +180,7 @@
       "resources": [
         {
           "apiVersion": "2020-02-02-preview",
-          "type": "Microsoft.Sql/servers/auditingSettings",
+          "type": "auditingSettings",
           "name": "anotherName",
           "properties": {
             "isAzureMonitorTargetEnabled": false,

--- a/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
+++ b/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
@@ -189,6 +189,26 @@
           }
         }
       ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "name": "FailsSQLRetentionDaysRuleWithFullResourceTypeAndName",
+      "apiVersion": "2020-02-02-preview",
+      "properties": {
+        "kind": "v12.0"
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-02-02-preview",
+          "type": "Microsoft.Sql/servers/auditingSettings",
+          "name": "FailsSQLRetentionDaysRuleWithFullResourceTypeAndName/default",
+          "properties": {
+            "isAzureMonitorTargetEnabled": false,
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').PrimaryEndpoints.Blob]",
+            "retentionDays": 45
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
+++ b/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/SQLServerAuditingSettings.badtemplate
@@ -209,6 +209,66 @@
           }
         }
       ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "name": "EndsInDefaultButNotOnlyDefault",
+      "apiVersion": "2020-02-02-preview",
+      "properties": {
+        "kind": "v12.0"
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-02-02-preview",
+          "type": "auditingSettings",
+          "name": "adefault",
+          "properties": {
+            "isAzureMonitorTargetEnabled": false,
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').PrimaryEndpoints.Blob]",
+            "retentionDays": 45
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "name": "StartsWithDefaultButNotOnlyDefault",
+      "apiVersion": "2020-02-02-preview",
+      "properties": {
+        "kind": "v12.0"
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-02-02-preview",
+          "type": "auditingSettings",
+          "name": "defaulta",
+          "properties": {
+            "isAzureMonitorTargetEnabled": false,
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').PrimaryEndpoints.Blob]",
+            "retentionDays": 45
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "name": "SecondSegmentIsNotOnlyDefault",
+      "apiVersion": "2020-02-02-preview",
+      "properties": {
+        "kind": "v12.0"
+      },
+      "resources": [
+        {
+          "apiVersion": "2020-02-02-preview",
+          "type": "Microsoft.Sql/servers/auditingSettings",
+          "name": "WithAlmostDefaultAuditing/defaulta",
+          "properties": {
+            "isAzureMonitorTargetEnabled": false,
+            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').PrimaryEndpoints.Blob]",
+            "retentionDays": 45
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/Analyzer.Core.BuiltInRuleTests/Tests/TA-000028.json
+++ b/src/Analyzer.Core.BuiltInRuleTests/Tests/TA-000028.json
@@ -16,6 +16,18 @@
       {
         "LineNumber": 148,
         "Description": "retentionDays not set to a value equal to 0 or greater than 90"
+      },
+      {
+        "LineNumber": 206,
+        "Description": "isAzureMonitorTargetEnabled set to false, in auditingSettings resource defined with full resource type and name"
+      },
+      {
+        "LineNumber": 207,
+        "Description": "storageEndpoint is not an empty string, in auditingSettings resource defined with full resource type and name"
+      },
+      {
+        "LineNumber": 208,
+        "Description": "retentionDays not set to a value equal to 0 or greater than 90, in auditingSettings resource defined with full resource type and name"
       }
     ]
   }

--- a/src/Analyzer.Core/Rules/BuiltInRules.json
+++ b/src/Analyzer.Core/Rules/BuiltInRules.json
@@ -717,7 +717,7 @@
               },
               {
                 "path": "name",
-                "regex": "default|\\/default"
+                "regex": "^default$|/default$"
               }
             ]
           },

--- a/src/Analyzer.Core/Rules/BuiltInRules.json
+++ b/src/Analyzer.Core/Rules/BuiltInRules.json
@@ -700,7 +700,7 @@
       },
       "allOf": [
         {
-          "resourceType": "Microsoft.Sql/servers/auditingSettings",
+          "resourceType": "auditingSettings",
           "where": {
             "path": "name",
             "equals": "default"

--- a/src/Analyzer.Core/Rules/BuiltInRules.json
+++ b/src/Analyzer.Core/Rules/BuiltInRules.json
@@ -700,10 +700,26 @@
       },
       "allOf": [
         {
-          "resourceType": "auditingSettings",
+          "path": "resources[*]",
           "where": {
-            "path": "name",
-            "equals": "default"
+            "allOf": [
+              {
+                "anyOf": [
+                  {
+                    "path": "type",
+                    "equals": "Microsoft.Sql/servers/auditingSettings"
+                  },
+                  {
+                    "path": "type",
+                    "equals": "auditingSettings"
+                  }
+                ]
+              },
+              {
+                "path": "name",
+                "regex": "default|\\/default"
+              }
+            ]
           },
           "anyOf": [
             {

--- a/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
+++ b/src/Analyzer.TemplateProcessor.UnitTests/ArmTemplateProcessorTests.cs
@@ -795,6 +795,45 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor.UnitTests
             AssertDictionariesAreEqual(expectedMapping, armTemplateProcessor.ResourceMappings);
         }
 
+        [TestMethod]
+        public void ProcessTemplate_ResourceNameWithIncorrectSegmentLength_ThrowsExpectedException()
+        {
+            string templateJson = @"{
+                ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+                ""contentVersion"": ""1.0.0.0"",
+                ""resources"": [
+                    {
+                        ""apiVersion"": ""2020-12-01"",
+                        ""type"": ""Microsoft.Compute/virtualMachines"",
+                        ""name"": ""vms"",
+                        ""properties"": {
+                        },
+                        ""resources"": [
+                            {
+                                ""type"": ""extensions"",
+                                ""name"": ""vms/InstallDomainController"",
+                                ""apiVersion"": ""2020-12-01"",
+                                ""properties"": {
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }";
+
+            ArmTemplateProcessor armTemplateProcessor = new ArmTemplateProcessor(templateJson);
+
+            try
+            {
+                var template = armTemplateProcessor.ProcessTemplate();
+                Assert.Fail("No exception was thrown");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("incorrect segment lengths"));
+            }
+        }
+
         private string GenerateTemplateWithOutputs(string outputValue)
         {
             return string.Format(@"{{

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -123,9 +123,15 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
             {
                 TemplateEngine.ProcessTemplateLanguageExpressions(template, apiVersion);
             }
-            catch
+            catch (Exception ex)
             {
-                // Do not throw if there was an issue with evaluating language expressions
+                if (ex.Message.Contains("incorrect segment lengths")) {
+                    // Processing stops when the error is found: some resources could be missing their
+                    // updated DependsOn and Name properties, that are needed for the remaining template processing
+                    throw ex;
+                }
+
+                // Do not throw if there was another issue with evaluating language expressions
             }
 
             MapTopLevelResources(template, copyNameMap);

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
                     // Processing stops when the error is found: some resources could be missing
                     // information that is needed for the remaining template processing,
                     // like updated values in their DependsOn and Name properties
-                    throw ex;
+                    throw;
                 }
 
                 // Do not throw if there was another issue with evaluating language expressions

--- a/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
+++ b/src/Analyzer.TemplateProcessor/ArmTemplateProcessor.cs
@@ -126,8 +126,9 @@ namespace Microsoft.Azure.Templates.Analyzer.TemplateProcessor
             catch (Exception ex)
             {
                 if (ex.Message.Contains("incorrect segment lengths")) {
-                    // Processing stops when the error is found: some resources could be missing their
-                    // updated DependsOn and Name properties, that are needed for the remaining template processing
+                    // Processing stops when the error is found: some resources could be missing
+                    // information that is needed for the remaining template processing,
+                    // like updated values in their DependsOn and Name properties
                     throw ex;
                 }
 


### PR DESCRIPTION
Closes #182 

Related issue: https://github.com/Azure/azure-quickstart-templates/issues/11968
In this case, not having the updated Name property in the resource is causing the problem, but we had an issue with DependsOn also some months ago

I assumed that `// Do not throw if there was another issue with evaluating language expressions` means there are other exceptions we want to ignore

I'm checking the message contents instead of the exception type because it's just a generic `TemplateValidationException`