### PR TITLE
Fix SARIF reporting with PowerShell results

### DIFF
--- a/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
+++ b/src/Analyzer.Cli.NuGet/Analyzer.Cli.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Azure.Templates.Analyzer.CommandLine</id>
     <!-- Also update version in Analyzer.Core nuspec and Directory.Build.props. -->
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <authors>Microsoft</authors>
     <description>A command line interface for Azure.Templates.Analyzer.Core - an ARM Template scanner for security misconfiguration and best practices</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
+++ b/src/Analyzer.Core.NuGet/Analyzer.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Azure.Templates.Analyzer.Core</id>
     <!-- Also update version in Analyzer.Cli nuspec and Directory.Build.props. -->
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <authors>Microsoft</authors>
     <description>ARM Template scanner for security misconfiguration and best practices</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
+++ b/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
@@ -58,6 +58,31 @@ namespace Microsoft.Azure.Templates.Analyzer.Core.UnitTests
             }
         }
 
+        [TestMethod]
+        public void AnalyzeTemplate_NotUsingPowerShell_NoPowerShellViolations()
+        {
+            // Arrange
+            string[] resourceProperties = {
+                GenerateResource(
+                    @"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantIdValue"" } }",
+                    "Microsoft.ServiceFabric/clusters", "resource1")
+            };
+            string template = GenerateTemplate(resourceProperties);
+
+            var evaluations = templateAnalyzer.AnalyzeTemplate(
+                template,
+                templateFilePath: @"..\..\..\..\Analyzer.PowerShellRuleEngine.UnitTests\templates\error_without_line_number.json", // This file has violations from TTK rules
+                usePowerShell: false);
+
+            var evaluationsWithResults = evaluations.ToList().FindAll(evaluation => evaluation.HasResults); // EvaluateRulesAgainstTemplate will always return at least an evaluation for each built-in rule
+
+            // There should be no evaluations with failures because TTK should not have run
+            foreach(IEvaluation evaluation in evaluationsWithResults)
+            {
+                Assert.IsTrue(evaluation.Passed);
+            }
+        }
+
         private string GenerateTemplate(string[] resourceProperties)
         {
             return string.Format(@"{{

--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -56,8 +56,9 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
         /// <param name="template">The ARM Template JSON</param>
         /// <param name="parameters">The parameters for the ARM Template JSON</param>
         /// <param name="templateFilePath">The ARM Template file path. (Needed to run arm-ttk checks.)</param>
+        /// <param name="usePowerShell">Whether or not to use PowerShell rules to analyze the template.</param>
         /// <returns>An enumerable of TemplateAnalyzer evaluations.</returns>
-        public IEnumerable<IEvaluation> AnalyzeTemplate(string template, string parameters = null, string templateFilePath = null)
+        public IEnumerable<IEvaluation> AnalyzeTemplate(string template, string parameters = null, string templateFilePath = null, bool usePowerShell = true)
         {
             if (template == null) throw new ArgumentNullException(nameof(template));
 
@@ -86,7 +87,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
             {
                 IEnumerable<IEvaluation> evaluations = jsonRuleEngine.AnalyzeTemplate(templateContext);
 
-                if (templateContext.TemplateIdentifier != null)
+                if (usePowerShell && templateContext.TemplateIdentifier != null)
                 {
                     var powerShellRuleEngine = new PowerShellRuleEngine();
                     evaluations = evaluations.Concat(powerShellRuleEngine.AnalyzeTemplate(templateContext));

--- a/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
+++ b/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
 
             foreach (PowerShellRuleEvaluation evaluation in evaluations)
             {
+                Assert.IsFalse(string.IsNullOrWhiteSpace(evaluation.RuleId));
+                Assert.IsFalse(string.IsNullOrWhiteSpace(evaluation.RuleDescription));
+                Assert.IsNotNull(evaluation.Recommendation);
+
                 if (evaluation.Passed)
                 {
                     Assert.IsFalse(evaluation.HasResults);
@@ -131,13 +135,16 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
 
             var powerShellRuleEngineWrongPath = new PowerShellRuleEngine();
             var evaluations = powerShellRuleEngineWrongPath.AnalyzeTemplate(templateContext);
-            Assert.AreEqual(0, evaluations.Count());
 
-            System.IO.Directory.Move(wrongTTKFolderName, TTKFolderName);
-
-            var powerShellRuleEngine = new PowerShellRuleEngine();
-            evaluations = powerShellRuleEngine.AnalyzeTemplate(templateContext);
-            Assert.AreEqual(1, evaluations.Count());
+            try
+            {
+                Assert.AreEqual(0, evaluations.Count());
+            }
+            finally
+            {
+                // Ensure directory is moved back in case of test failure
+                System.IO.Directory.Move(wrongTTKFolderName, TTKFolderName);
+            }
         }
 
         [TestMethod]

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -85,8 +85,10 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
                     {
                         evaluationResults.Add(new PowerShellRuleResult(false, lineNumber));
                     }
+
+                    var ruleId = (executionResult.Name as string)?.Replace(" ", "") ?? string.Empty;
                     var ruleDescription = executionResult.Name + ". " + uniqueError.Key;
-                    evaluations.Add(new PowerShellRuleEvaluation("", ruleDescription, false, evaluationResults));
+                    evaluations.Add(new PowerShellRuleEvaluation(ruleId, ruleDescription, false, evaluationResults));
                 }
             }
 

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEvaluation.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEvaluation.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
         {
             RuleId = ruleId;
             RuleDescription = ruleDescription;
+            Recommendation = string.Empty;
             Passed = passed;
             Results = results;
             Evaluations = new List<IEvaluation>();

--- a/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             foreach (var evaluation in testcases.Where(e => !e.Passed))
             {
                 expected.Append($"{ConsoleReportWriter.IndentedNewLine}{(!string.IsNullOrEmpty(evaluation.RuleId) ? $"{evaluation.RuleId}: " : string.Empty)}{evaluation.RuleDescription}");
+                if (!string.IsNullOrWhiteSpace(evaluation.Recommendation)) expected.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}Recommendation: {evaluation.Recommendation}");
                 expected.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}More information: {evaluation.HelpUri}");
                 expected.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}Result: {(evaluation.Passed ? "Passed" : "Failed")} ");
                 expected.Append(GetLineNumbers(evaluation));

--- a/src/Analyzer.Reports/ConsoleReportWriter.cs
+++ b/src/Analyzer.Reports/ConsoleReportWriter.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
                 {
                     string resultString = GenerateResultString(evaluation);
                     var output = $"{IndentedNewLine}{(evaluation.RuleId != "" ? $"{evaluation.RuleId}: " : "")}{evaluation.RuleDescription}" +
+                    (!string.IsNullOrWhiteSpace(evaluation.Recommendation) ? $"{TwiceIndentedNewLine}Recommendation: {evaluation.Recommendation}" : "") +
                     $"{TwiceIndentedNewLine}More information: {evaluation.HelpUri}" +
                     $"{TwiceIndentedNewLine}Result: {(evaluation.Passed ? "Passed" : "Failed")} {resultString}";
                     Console.WriteLine(output);

--- a/src/Analyzer.Reports/SarifReportWriter.cs
+++ b/src/Analyzer.Reports/SarifReportWriter.cs
@@ -183,7 +183,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
             }
         }
 
-        internal static string AppendPeriod(string text) => 
+        internal static string AppendPeriod(string text) =>
+            text == null ? string.Empty :
             text.EndsWith(PeriodString, StringComparison.OrdinalIgnoreCase) ? text : text + PeriodString;
 
         /// <inheritdoc/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Also update version in nuspec files for Analyzer.Core and Analyzer.Cli. -->
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>


### PR DESCRIPTION
PowerShell results don't play well with SARIF right now because we're limited by the strings the ARM TTK outputs for descriptions, and the SARIF writer assumes each rule will have a standard description that's constant for all violations, in addition to a possible instance-specific message for failures.
- The JSON rules have a standard description that's the same for all rules, but lacks instance-specific messaging.
- The TTK has instance-specific messaging, but no standard description (failures simply write to the console output, and BPA captures those messages, which contain details of the specific failures).
  - This means the first violation of a given PowerShell rule becomes the "standard description" for all other violations, which is really confusing when the description contains mentions of specific items in the template that only apply to the first violation.

SARIF result writer would also throw an exception when writing results from PowerShell rule execution because `IEvaluation.Recommendation` was null.  This fixes that (closes #203), though PS violations still don't play well in SARIF.

To smooth out these wrinkles while we work on a long-term solution, this PR has the following changes:
- Puts PowerShell rule execution behind a CLI flag, so it's disabled by default
- Add `null`-check in the SARIF result writer
- Populate `PowerShellEvaluation.Recommendation` with an empty string for safety
- Populate `PowerShellEvaluation.RuleId` with something simple for now
- Include rule recommendation text in console output if it's available

To speed up release of this fix, this also includes a version increment to `0.1.1`