### PR TITLE
Splitting rule analysis on templates into multiple Evaluations

### DIFF
--- a/docs/authoring-json-rules.md
+++ b/docs/authoring-json-rules.md
@@ -403,11 +403,12 @@ In contrast to the first example, the `allOf` operator in the example above woul
 **NOTE:** In both examples above, `"path": "properties.osProfile.computerName"` is specified *inside* the `allOf` operators.  This is important because of how [scopes](#scopes) are determined.  If it was instead specified outside the operator (as a sibling to `where`), it would narrow the **outer** scope to that path.  That path would then be passed into `where`, resulting in `"path": "apiVersion"` and `"path": "name"` (inside `where` in the examples) being appended to *properties.osProfile.computerName* in the outer scope, which is not the intent.
 
 ## Wildcard Behavior
-The `path` in an `Evaluation` can specify the '\*' character as a wildcard.  '\*' can be used to match any full property name or as the index into an array (selecting all elements of the array).  When a wildcard is used, zero or more paths in the template will be found that match `path`.  If zero are found, the operator in the `Evaluation` is skipped, as there is nothing to evaluate.  If two or more are found, the operator evaluates each path individually and the results are logically 'and'ed together.
+The `path` in an `Evaluation` can specify the '\*' character as a wildcard.  '\*' can be used to match any full property name or as the index into an array (selecting all elements of the array).  When a wildcard is used, zero or more paths in the template will be found that match `path`.  If zero paths are found, the operator in the `Evaluation` is skipped, as there is nothing to evaluate.  If two or more paths are found, the operator evaluates each path individually and treats each path as its own result; then, if the operator evaluating the path(s) is contained within an `allOf` or `anyOf`, the results will be combined according to those operators - otherwise, they will be reported individually.
 
 When using a wildcard for a property name, '\*' must replace the entire name of a property (such as *property.\** or *property.\*.otherProperty*), being the only character between the periods.  Wildcards for partial property names (e.g. *property.\*id*) are **not** supported.  When using a wildcard as an index into an array (such as *property[\*]*), '\*' must be the only character between the '[]' characters.
 
 Examples:
+
 ``` js
 {
     "resourceType": "Microsoft.Compute/virtualMachines",
@@ -417,6 +418,7 @@ Examples:
         // resources[0].properties.osProfile.adminPassword
 }
 ```
+
 ``` js
 {
     "resourceType": "Microsoft.Compute/virtualMachines",
@@ -424,12 +426,14 @@ Examples:
         // resources[0].properties.networkProfile.networkInterfaces[0]
 }
 ```
+
 ``` js
 {
     "path": "resources[*]" // Returns all resources (only one resource is defined):
         // resources[0]
 }
 ```
+
 ``` js
 {
     "path": "outputs.*" // Returns all outputs:
@@ -437,6 +441,7 @@ Examples:
         // outputs.customOutput
 }
 ```
+
 ``` js
 {
     "resourceType": "Microsoft.Compute/virtualMachines",

--- a/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/AppServicesLogs.badtemplate
+++ b/src/Analyzer.Core.BuiltInRuleTests/TestTemplates/AppServicesLogs.badtemplate
@@ -71,6 +71,34 @@
       "apiVersion": "2019-08-01",
       "type": "Microsoft.Web/sites",
       "kind": "app",
+      "name": "diagLogsDisabledInSiteConfigPropertyAndDependentConfig",
+      "location": "[parameters('location')]",
+      "properties": {
+        "siteConfig": {
+          "detailedErrorLoggingEnabled": false,
+          "httpLoggingEnabled": false,
+          "requestTracingEnabled": false
+        }
+      }
+    },
+    {
+      "apiVersion": "2019-08-01",
+      "type": "Microsoft.Web/sites",
+      "kind": "app",
+      "name": "diagLogsDisabledInSiteConfigPropertyButEnabledInDependentConfig",
+      "location": "[parameters('location')]",
+      "properties": {
+        "siteConfig": {
+          "detailedErrorLoggingEnabled": false,
+          "httpLoggingEnabled": false,
+          "requestTracingEnabled": false
+        }
+      }
+    },
+    {
+      "apiVersion": "2019-08-01",
+      "type": "Microsoft.Web/sites",
+      "kind": "app",
       "name": "diagLogsEnabledInSiteConfigProperty",
       "location": "[parameters('location')]",
       "properties": {
@@ -88,7 +116,7 @@
       "name": "sitesConfig/diagLogsDisabled",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', 'diagLogsDisabledInSiteConfigProperty')]"
+        "[resourceId('Microsoft.Web/sites', 'diagLogsDisabledInSiteConfigPropertyAndDependentConfig')]"
       ],
       "properties": {
         "detailedErrorLoggingEnabled": false,
@@ -103,7 +131,7 @@
       "name": "sitesConfig/diagLogsEnabled",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', 'diagLogsDisabledInSiteConfigProperty')]"
+        "[resourceId('Microsoft.Web/sites', 'diagLogsDisabledInSiteConfigPropertyButEnabledInDependentConfig')]"
       ],
       "properties": {
         "detailedErrorLoggingEnabled": true,

--- a/src/Analyzer.Core.BuiltInRuleTests/Tests/TA-000001.json
+++ b/src/Analyzer.Core.BuiltInRuleTests/Tests/TA-000001.json
@@ -3,8 +3,8 @@
     "Template": "AppServicesLogs", // didn't use the existing AppServices template because AppServiceWebApp_HTTPS would trigger for all the new resources, and AppService_EnableDiagLogs for all the already existing ones
     "ReportedFailures": [
       // The resources between lines 14 and 55 are not reported because their kind property includes "functionapp" or "linux"
-      // The one between lines 70 and 83 is not reported because the siteConfig property has the desired values
-      // In lines 100-113 there's a resource that depends on another that doesn't fulfill the first property of the anyOf, but itself fulfills the second one
+      // The resource named "diagLogsEnabledInSiteConfigProperty" is not reported because the siteConfig property has the desired values
+      // The resource named "sitesConfig/diagLogsEnabled" depends on another that doesn't fulfill the first property of the anyOf (resource "diagLogsDisabledInSiteConfigPropertyButEnabledInDependentConfig"), but itself fulfills the second anyOf property
       // And the last one of sites/config type depends on a resource such that neither of them makes the anyOf properties true, but the first one is of Linux type
       {
         "LineNumber": 64,
@@ -19,19 +19,31 @@
         "Description": "requestTracingEnabled set to false"
       },
       {
-        "LineNumber": 94,
+        "LineNumber": 78,
+        "Description": "detailedErrorLoggingEnabled set to false in properties and in sites/config"
+      },
+      {
+        "LineNumber": 79,
+        "Description": "httpLoggingEnabled set to false in properties and in sites/config"
+      },
+      {
+        "LineNumber": 80,
+        "Description": "requestTracingEnabled set to false in properties and in sites/config"
+      },
+      {
+        "LineNumber": 122,
         "Description": "detailedErrorLoggingEnabled set to false in sites/config"
       },
       {
-        "LineNumber": 95,
+        "LineNumber": 123,
         "Description": "httpLoggingEnabled set to false in sites/config"
       },
       {
-        "LineNumber": 96,
+        "LineNumber": 124,
         "Description": "requestTracingEnabled set to false in sites/config"
       },
       {
-        "LineNumber": 138,
+        "LineNumber": 166,
         "Description": "httpLoggingEnabled set to false in a resource with detailedErrorLoggingEnabled and requestTracingEnabled as true"
       }
     ]

--- a/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
+++ b/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Azure.Templates.Analyzer.Core.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 1, true, DisplayName = "1 matching Resource with 1 passing evaluation")]
-        [DataRow(@"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.ServiceFabric/clusters", 1, false, DisplayName = "1 matching Resource with 1 failing evaluation")]
-        [DataRow(@"{ ""property1"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.Storage/storageAccounts", 0, false, DisplayName = "0 matching Resources with no results")]
-        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 1, false, @"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", DisplayName = "2 matching Resources with 1 passing evaluation")]
-        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 1, true, null, @"..\..\..\..\Analyzer.PowerShellRuleEngine.UnitTests\templates\success.json", DisplayName = "1 matching Resource with 1 passing evaluation, specifying a template file path")]
-        [DataRow(@"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.ServiceFabric/clusters", 2, false, null, @"..\..\..\..\Analyzer.PowerShellRuleEngine.UnitTests\templates\error_without_line_number.json", DisplayName = "1 matching Resource with 2 failing evaluations, specifying a template file path")]
-        public void AnalyzeTemplate_ValidInputValues_ReturnCorrectEvaluations(string resource1Properties, string resourceType, int expectedEvaluationCount, bool expectedEvaluationPassed, string resource2Properties = null, string templateFilePath = null)
+        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 1, 1, DisplayName = "1 matching Resource with 1 passing evaluation")]
+        [DataRow(@"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.ServiceFabric/clusters", 1, 0, DisplayName = "1 matching Resource with 1 failing evaluation")]
+        [DataRow(@"{ ""property1"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.Storage/storageAccounts", 0, 0, DisplayName = "0 matching Resources with no results")]
+        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 2, 1, @"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", DisplayName = "2 matching Resources with 1 passing evaluation")]
+        [DataRow(@"{ ""azureActiveDirectory"": { ""tenantId"": ""tenantId"" } }", "Microsoft.ServiceFabric/clusters", 1, 1, null, @"..\..\..\..\Analyzer.PowerShellRuleEngine.UnitTests\templates\success.json", DisplayName = "1 matching Resource with 1 passing evaluation, specifying a template file path")]
+        [DataRow(@"{ ""azureActiveDirectory"": { ""someProperty"": ""propertyValue"" } }", "Microsoft.ServiceFabric/clusters", 2, 0, null, @"..\..\..\..\Analyzer.PowerShellRuleEngine.UnitTests\templates\error_without_line_number.json", DisplayName = "1 matching Resource with 2 failing evaluations, specifying a template file path")]
+        public void AnalyzeTemplate_ValidInputValues_ReturnCorrectEvaluations(string resource1Properties, string resourceType, int expectedEvaluationCount, int expectedEvaluationPassCount, string resource2Properties = null, string templateFilePath = null)
         {
             // Arrange
             string[] resourceProperties = { GenerateResource(resource1Properties, resourceType, "resource1"), GenerateResource(resource2Properties, resourceType, "resource2") };
@@ -52,11 +52,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Core.UnitTests
             var evaluationsWithResults = evaluations.ToList().FindAll(evaluation => evaluation.HasResults); // EvaluateRulesAgainstTemplate will always return at least an evaluation for each built-in rule
 
             Assert.AreEqual(expectedEvaluationCount, evaluationsWithResults.Count);
-
-            foreach(IEvaluation evaluation in evaluationsWithResults)
-            {
-                Assert.AreEqual(expectedEvaluationPassed, evaluation.Passed);
-            }
+            Assert.AreEqual(expectedEvaluationPassCount, evaluationsWithResults.Count(e => e.Passed));
         }
 
         [TestMethod]

--- a/src/Analyzer.JsonRuleEngine.FunctionalTests/ScopeSelectionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.FunctionalTests/ScopeSelectionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
@@ -157,12 +158,12 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.FunctionalTe
                 : base(commonProperties)
             { }
 
-            public override JsonRuleEvaluation Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver lineNumberResolver = null)
+            public override IEnumerable<JsonRuleEvaluation> Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver lineNumberResolver = null)
             {
                 return base.EvaluateInternal(jsonScope, scope =>
                 {
                     EvaluationCallback(scope);
-                    return new JsonRuleResult();
+                    return new JsonRuleEvaluation(this, true, Enumerable.Empty<JsonRuleEvaluation>());
                 });
             }
         }

--- a/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new[] { new JsonRuleEvaluation(null, passed: false, results: new[] { new JsonRuleResult() }) };
+                    return new[] { new JsonRuleEvaluation(null, passed: false, result: new JsonRuleResult()) };
                 }
             };
 
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
+                    return new[] { new JsonRuleEvaluation(null, passed: true, evaluations: Array.Empty<JsonRuleEvaluation>()) };
                 }
             };
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new[] { new JsonRuleEvaluation(null, passed: true, results: new[] { new JsonRuleResult() }) };
+                    return new[] { new JsonRuleEvaluation(null, passed: true, result: new JsonRuleResult()) };
                 }
             };
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 {
                     // Track whether this was evaluated or not.
                     topLevelExpressionWasEvaluated = true;
-                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
+                    return new[] { new JsonRuleEvaluation(null, passed: true, evaluations: Array.Empty<JsonRuleEvaluation>()) };
                 }
             };
 
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 {
                     // If a non-null ILineNumberResolver was passed to this Where condition, record it to assert later.
                     lineNumberResolverWasAlwaysNull &= lineNumberResolver == null;
-                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
+                    return new[] { new JsonRuleEvaluation(null, passed: true, evaluations: Array.Empty<JsonRuleEvaluation>()) };
                 });
 
             // A top level mocked expression that contains a Where condition.
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             {
                 EvaluationCallback = pathResolver =>
                 {
-                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
+                    return new[] { new JsonRuleEvaluation(null, passed: true, evaluations: Array.Empty<JsonRuleEvaluation>()) };
                 }
             };
 

--- a/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/ExpressionTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new JsonRuleEvaluation(null, passed: false, results: new[] { new JsonRuleResult() });
+                    return new[] { new JsonRuleEvaluation(null, passed: false, results: new[] { new JsonRuleResult() }) };
                 }
             };
 
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>());
+                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
                 }
             };
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 EvaluationCallback = pathResolver =>
                 {
                     whereConditionWasEvaluated = true;
-                    return new JsonRuleEvaluation(null, passed: true, results: new[] { new JsonRuleResult() });
+                    return new[] { new JsonRuleEvaluation(null, passed: true, results: new[] { new JsonRuleResult() }) };
                 }
             };
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 {
                     // Track whether this was evaluated or not.
                     topLevelExpressionWasEvaluated = true;
-                    return new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>());
+                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
                 }
             };
 
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 {
                     // If a non-null ILineNumberResolver was passed to this Where condition, record it to assert later.
                     lineNumberResolverWasAlwaysNull &= lineNumberResolver == null;
-                    return new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>());
+                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
                 });
 
             // A top level mocked expression that contains a Where condition.
@@ -168,15 +168,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             {
                 EvaluationCallback = pathResolver =>
                 {
-                    return new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>());
+                    return new[] { new JsonRuleEvaluation(null, passed: true, results: Array.Empty<JsonRuleResult>()) };
                 }
             };
 
             // Evaluate scope - line number resolver should not be passed into Where condition
-            mockExpression.Evaluate(mockPathResolver.Object, new Mock<ILineNumberResolver>().Object);
-
-            // Set up a Result Callback to exercise both EvaluateInternal methods
-            mockExpression.ResultsCallback = resolver => new JsonRuleResult();
             mockExpression.Evaluate(mockPathResolver.Object, new Mock<ILineNumberResolver>().Object);
 
             Assert.IsTrue(lineNumberResolverWasAlwaysNull, "A non-null ILineNumberResolver was passed to a Where condition when it shouldn't have.");
@@ -189,18 +185,6 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             // Calls EvaluateInternal with Func<IJsonPathResolver, JsonRuleEvaluation>
             new MockExpression(new ExpressionCommonProperties { Path = "path" })
                 .Evaluate(null, new Mock<ILineNumberResolver>().Object);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void EvaluateInternalGetResult_NullScope_ThrowsException()
-        {
-            // Calls EvaluateInternal with Func<IJsonPathResolver, JsonRuleResult>
-            var expression = new MockExpression(new ExpressionCommonProperties { Path = "path" })
-            {
-                ResultsCallback = r => (JsonRuleResult)null
-            };
-            expression.Evaluate(null, new Mock<ILineNumberResolver>().Object);
         }
 
         [TestMethod]

--- a/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEngineTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEngineTests.cs
@@ -96,10 +96,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 Assert.AreEqual($"RuleId {i}", evaluation.RuleId);
                 Assert.AreEqual(expectedFileId, evaluation.FileIdentifier);
 
-                foreach (var result in evaluation.Results)
-                {
-                    Assert.AreEqual(expectedLineNumber, result.LineNumber);
-                }
+                Assert.AreEqual(expectedLineNumber, evaluation.Result.LineNumber);
             }
         }
 
@@ -226,7 +223,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             Assert.AreEqual($"RuleId 0", evaluation.RuleId);
             Assert.AreEqual(expectedFileId, evaluation.FileIdentifier);
 
-            Assert.AreEqual(0, evaluation.Results.Count());
+            Assert.IsNull(evaluation.Result);
 
             AssertEvaluationsAndResultsAreAsExpected(evaluation, expectedLineNumber);
         }
@@ -237,10 +234,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             {
                 if ((evaluationResult as JsonRuleEvaluation).Expression is LeafExpression)
                 {
-                    foreach (var result in evaluationResult.Results)
-                    {
-                        Assert.AreEqual(expectedLineNumber, result.LineNumber);
-                    }
+                    Assert.AreEqual(expectedLineNumber, evaluationResult.Result.LineNumber);
                 }
                 else
                 {

--- a/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEvaluationTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/JsonRuleEvaluationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         {
             Assert.AreEqual(
                 "testRule",
-                new JsonRuleEvaluation(null, true, new JsonRuleResult[0])
+                new JsonRuleEvaluation(null, true, Enumerable.Empty<JsonRuleEvaluation>())
                 {
                     RuleDefinition = new RuleDefinition { Id = "testRule" }
                 }
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         {
             Assert.AreEqual(
                 "test rule",
-                new JsonRuleEvaluation(null, true, new JsonRuleResult[0])
+                new JsonRuleEvaluation(null, true, Enumerable.Empty<JsonRuleEvaluation>())
                 {
                     RuleDefinition = new RuleDefinition { Description = "test rule" }
                 }
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         {
             Assert.AreEqual(
                 "test recommendation",
-                new JsonRuleEvaluation(null, true, new JsonRuleResult[0])
+                new JsonRuleEvaluation(null, true, Enumerable.Empty<JsonRuleEvaluation>())
                 {
                     RuleDefinition = new RuleDefinition { Recommendation = "test recommendation" }
                 }
@@ -54,109 +54,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         {
             Assert.AreEqual(
                 "https://helpUri",
-                new JsonRuleEvaluation(null, true, new JsonRuleResult[0])
+                new JsonRuleEvaluation(null, true, Enumerable.Empty<JsonRuleEvaluation>())
                 {
                     RuleDefinition = new RuleDefinition { HelpUri = "https://helpUri" }
                 }
                 .HelpUri);
-        }
-
-        [DataTestMethod]
-        [DataRow(3, 3, DisplayName = "3/3 results are true")]
-        [DataRow(3, 2, DisplayName = "2/3 results are true")]
-        [DataRow(3, 0, DisplayName = "0/3 results are true")]
-        [DataRow(0, 0, DisplayName = "No results")]
-        public void GetResultsEvaluatedTrueFalse_ThreeResults_ExpectedNumberOfResultsReturned(int totalResults, int expectedTrue)
-        {
-            // Arrange
-            int expectedFalse = totalResults - expectedTrue;
-
-            List<JsonRuleResult> results = new List<JsonRuleResult>();
-
-            for (int i = 0; i < expectedTrue; i++)
-            {
-                results.Add(new JsonRuleResult { Passed = true });
-            }
-
-            for (int i = 0; i < expectedFalse; i++)
-            {
-                results.Add(new JsonRuleResult { Passed = false });
-            }
-
-            JsonRuleEvaluation jsonRuleEvaluation = new JsonRuleEvaluation(null, true, results);
-
-            // Act
-            var resultsEvaluatedTrue = jsonRuleEvaluation.ResultsEvaluatedTrue;
-            var resultsEvaluatedFalse = jsonRuleEvaluation.ResultsEvaluatedFalse;
-
-            // Assert
-            Assert.AreEqual(totalResults, results.Count());
-            Assert.AreEqual(expectedTrue, resultsEvaluatedTrue.Count());
-            Assert.AreEqual(expectedFalse, resultsEvaluatedFalse.Count());
-        }
-
-        [TestMethod]
-        public void GetResultsEvaluatedTrueFalse_ResultsNotSet_ReturnZeroResults()
-        {
-            // Arrange
-            JsonRuleEvaluation jsonRuleEvaluation = new JsonRuleEvaluation(null, true, new List<JsonRuleEvaluation>());
-
-            // Act
-            var resultsEvaluatedTrue = jsonRuleEvaluation.ResultsEvaluatedTrue;
-            var resultsEvaluatedFalse = jsonRuleEvaluation.ResultsEvaluatedFalse;
-
-            // Assert
-            Assert.AreEqual(0, resultsEvaluatedTrue.Count());
-            Assert.AreEqual(0, resultsEvaluatedFalse.Count());
-        }
-
-        [DataTestMethod]
-        [DataRow(3, 3, DisplayName = "3/3 evaluations are true")]
-        [DataRow(3, 2, DisplayName = "2/3 evaluations are true")]
-        [DataRow(3, 0, DisplayName = "0/3 evaluations are true")]
-        [DataRow(0, 0, DisplayName = "No evaluations")]
-        public void GetEvaluationsEvaluatedTrueFalse_ThreeEvaluations_ExpectedNumberOfEvaluationsReturned(int totalEvaluations, int expectedTrue)
-        {
-            // Arrange
-            int expectedFalse = totalEvaluations - expectedTrue;
-
-            List<JsonRuleEvaluation> evaluations = new List<JsonRuleEvaluation>();
-
-            for (int i = 0; i < expectedTrue; i++)
-            {
-                evaluations.Add(new JsonRuleEvaluation(null, true, new JsonRuleResult[0]));
-            }
-
-            for (int i = 0; i < expectedFalse; i++)
-            {
-                evaluations.Add(new JsonRuleEvaluation(null, false, new JsonRuleResult[0]));
-            }
-
-            JsonRuleEvaluation jsonRuleEvaluation = new JsonRuleEvaluation(null, true, evaluations);
-
-            // Act
-            var evaluationsEvaluatedTrue = jsonRuleEvaluation.EvaluationsEvaluatedTrue;
-            var evaluationsEvaluatedFalse = jsonRuleEvaluation.EvaluationsEvaluatedFalse;
-
-            // Assert
-            Assert.AreEqual(totalEvaluations, evaluations.Count());
-            Assert.AreEqual(expectedTrue, evaluationsEvaluatedTrue.Count());
-            Assert.AreEqual(expectedFalse, evaluationsEvaluatedFalse.Count());
-        }
-
-        [TestMethod]
-        public void GetEvaluationsEvaluatedTrueFalse_EvaluationsNotSet_ReturnZeroEvaluations()
-        {
-            // Arrange
-            JsonRuleEvaluation jsonRuleEvaluation = new JsonRuleEvaluation(null, true, new List<JsonRuleResult>());
-
-            // Act
-            var evaluationsEvaluatedTrue = jsonRuleEvaluation.EvaluationsEvaluatedTrue;
-            var evaluationsEvaluatedFalse = jsonRuleEvaluation.EvaluationsEvaluatedFalse;
-
-            // Assert
-            Assert.AreEqual(0, evaluationsEvaluatedTrue.Count());
-            Assert.AreEqual(0, evaluationsEvaluatedFalse.Count());
         }
 
         [TestMethod]
@@ -183,29 +85,6 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         }
 
         [TestMethod]
-        public void Results_IterateResultsMultipleTimes_IterationIsCached()
-        {
-            int iterationCounter = 0;
-
-            IEnumerable<JsonRuleResult> GenerateResultEnumerable()
-            {
-                iterationCounter++;
-                yield return new JsonRuleResult();
-            }
-
-            var testEvaluation = new JsonRuleEvaluation(null, true, GenerateResultEnumerable());
-
-            // Call each method that would iterate Evaluations, making sure the original Enumerable
-            // is only ever iterated a single time.
-            _ = testEvaluation.Results;
-            _ = testEvaluation.ResultsEvaluatedFalse;
-            _ = testEvaluation.ResultsEvaluatedTrue;
-            _ = testEvaluation.HasResults;
-            _ = testEvaluation.Results;
-            Assert.AreEqual(1, iterationCounter);
-        }
-
-        [TestMethod]
         public void HasResults_NestedEvaluationsWithResults_ReturnsTrue()
         {
             var evaluationWithNestedResults = new JsonRuleEvaluation(
@@ -216,18 +95,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                     new JsonRuleEvaluation(
                         null,
                         true,
-                        new []
-                        {
-                            new JsonRuleResult(),
-                            new JsonRuleResult()
-                        }),
+                        new JsonRuleResult()),
                     new JsonRuleEvaluation(
                         null,
                         true,
-                        new []
-                        {
-                            new JsonRuleResult()
-                        })
+                        new JsonRuleResult())
                 });
 
             Assert.IsTrue(evaluationWithNestedResults.HasResults);
@@ -258,7 +130,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         [ExpectedException(typeof(ArgumentNullException))]
         public void Constructor_NullResults_ThrowsException()
         {
-            new JsonRuleEvaluation(null, true, results: null);
+            new JsonRuleEvaluation(null, true, result: null);
         }
 
         [TestMethod]

--- a/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             // Assert
             Assert.AreEqual(1, evaluationOutcome.Count);
 
-            var results = evaluationOutcome[0].Results.ToList();
+            var iresult = evaluationOutcome[0].Result;
 
             // Verify actions on resolvers.
 
@@ -113,10 +113,9 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 
             Assert.AreEqual(expectedEvaluationResult, evaluationOutcome[0].Passed);
 
-            Assert.AreEqual(1, results.Count);
-            Assert.AreEqual(expectedEvaluationResult, results.First().Passed);
+            Assert.AreEqual(expectedEvaluationResult, iresult.Passed);
 
-            var result = results.First() as JsonRuleResult;
+            var result = iresult as JsonRuleResult;
             Assert.AreEqual(expectedPathEvaluated, result.JsonPath);
             Assert.AreEqual(lineNumber, result.LineNumber);
         }
@@ -139,10 +138,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 
             Assert.AreEqual(1, evaluationOutcome.Count);
 
-            var results = evaluationOutcome[0].Results.ToList();
-
-            Assert.AreEqual(1, results.Count);
-            Assert.AreEqual(0, results[0].LineNumber);
+            Assert.AreEqual(0, evaluationOutcome[0].Result.LineNumber);
         }
 
         [TestMethod]

--- a/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/LeafExpressionTests.cs
@@ -87,18 +87,22 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             var leafExpression = new LeafExpression(mockLeafExpressionOperator.Object, new ExpressionCommonProperties { ResourceType = resourceType, Path = path });
 
             // Act
-            var evaluation = leafExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, jsonLineNumberResolver: mockLineResolver.Object);
-            var results = evaluation.Results.ToList();
+            var evaluationOutcome = leafExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, jsonLineNumberResolver: mockLineResolver.Object).ToList();
 
             // Assert
+            Assert.AreEqual(1, evaluationOutcome.Count);
+
+            var results = evaluationOutcome[0].Results.ToList();
+
             // Verify actions on resolvers.
 
             // If a resource type is passed, it should resolve for the resource type, and the path should be resolved on the mock resource type.
             // If no resource type is passed, it should resolve the path directly and not use the mock resource type.
-            // ResolveResourceType should never be called on the mock returned from resolving resource types already.
             mockJsonPathResolver.Verify(s => s.Resolve(It.Is<string>(p => string.Equals(p, path))), Times.Exactly(resourceType == null ? 1 : 0));
             mockJsonPathResolver.Verify(s => s.ResolveResourceType(It.Is<string>(r => string.Equals(r, resourceType))), Times.Exactly(resourceType == null ? 0 : 1));
             mockResourcesResolved.Verify(s => s.Resolve(It.Is<string>(p => string.Equals(p, path))), Times.Exactly(resourceType == null ? 0 : 1));
+
+            // ResolveResourceType should never be called on the mock returned from resolving resource types already.
             mockResourcesResolved.Verify(s => s.ResolveResourceType(It.IsAny<string>()), Times.Never);
 
             // The original mock is returned from both mocks when calling Resolve for a path, so the JToken should always come from it.
@@ -107,7 +111,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 
             mockLeafExpressionOperator.Verify(o => o.EvaluateExpression(It.Is<JToken>(token => token == jsonToEvaluate)), Times.Once);
 
-            Assert.AreEqual(expectedEvaluationResult, evaluation.Passed);
+            Assert.AreEqual(expectedEvaluationResult, evaluationOutcome[0].Passed);
 
             Assert.AreEqual(1, results.Count);
             Assert.AreEqual(expectedEvaluationResult, results.First().Passed);
@@ -131,7 +135,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 .Returns(false);
 
             var leafExpression = new LeafExpression(mockLeafExpressionOperator.Object, new ExpressionCommonProperties { Path = "" });
-            var results = leafExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, jsonLineNumberResolver: null).Results.ToList();
+            var evaluationOutcome = leafExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, jsonLineNumberResolver: null).ToList();
+
+            Assert.AreEqual(1, evaluationOutcome.Count);
+
+            var results = evaluationOutcome[0].Results.ToList();
 
             Assert.AreEqual(1, results.Count);
             Assert.AreEqual(0, results[0].LineNumber);

--- a/src/Analyzer.JsonRuleEngine.UnitTests/NotExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/NotExpressionTests.cs
@@ -47,11 +47,9 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                     .Returns(new List<IJsonPathResolver> { mockJsonPathResolver.Object });
             }
 
-            var leafExpressionresults = new JsonRuleResult[] { jsonRuleResult };
-
             mockLeafExpression
                 .Setup(s => s.Evaluate(mockJsonPathResolver.Object, mockLineResolver))
-                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression.Object, expectedEvaluationResult, leafExpressionresults) });
+                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression.Object, expectedEvaluationResult, jsonRuleResult) });
 
             var notExpression = new NotExpression(mockLeafExpression.Object, new ExpressionCommonProperties { ResourceType = resourceType, Path = path });
 
@@ -63,7 +61,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 
             var evaluation = evaluationOutcome[0];
             Assert.AreEqual(expectedEvaluationResult, evaluation.Passed);
-            Assert.AreEqual(expectedEvaluationResult, evaluation.Results.First().Passed);
+            Assert.AreEqual(expectedEvaluationResult, evaluation.Result.Passed);
 
             Assert.IsTrue(mockLeafExpression.Object.Operator.IsNegative);
         }

--- a/src/Analyzer.JsonRuleEngine.UnitTests/NotExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/NotExpressionTests.cs
@@ -51,14 +51,17 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
 
             mockLeafExpression
                 .Setup(s => s.Evaluate(mockJsonPathResolver.Object, mockLineResolver))
-                .Returns(new JsonRuleEvaluation(mockLeafExpression.Object, expectedEvaluationResult, leafExpressionresults));
+                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression.Object, expectedEvaluationResult, leafExpressionresults) });
 
             var notExpression = new NotExpression(mockLeafExpression.Object, new ExpressionCommonProperties { ResourceType = resourceType, Path = path });
 
             // Act
-            var evaluation = notExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, mockLineResolver);
+            var evaluationOutcome = notExpression.Evaluate(jsonScope: mockJsonPathResolver.Object, mockLineResolver).ToList();
 
             // Assert
+            Assert.AreEqual(1, evaluationOutcome.Count);
+
+            var evaluation = evaluationOutcome[0];
             Assert.AreEqual(expectedEvaluationResult, evaluation.Passed);
             Assert.AreEqual(expectedEvaluationResult, evaluation.Results.First().Passed);
 

--- a/src/Analyzer.JsonRuleEngine.UnitTests/StructuredExpressionTests.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/StructuredExpressionTests.cs
@@ -79,16 +79,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                     .Returns(new List<IJsonPathResolver> { mockJsonPathResolver.Object });
             }
 
-            var results1 = new JsonRuleResult[] { jsonRuleResult1 };
-            var results2 = new JsonRuleResult[] { jsonRuleResult2 };
-
             mockLeafExpression1
                 .Setup(s => s.Evaluate(mockJsonPathResolver.Object, mockLineResolver))
-                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression1.Object, evaluation1, results1) });
+                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression1.Object, evaluation1, jsonRuleResult1) });
 
             mockLeafExpression2
                 .Setup(s => s.Evaluate(mockJsonPathResolver.Object, mockLineResolver))
-                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression2.Object, evaluation2, results2) });
+                .Returns(new[] { new JsonRuleEvaluation(mockLeafExpression2.Object, evaluation2, jsonRuleResult2) });
 
             var expressionArray = new Expression[] { mockLeafExpression1.Object, mockLeafExpression2.Object };
 
@@ -118,7 +115,6 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
                 // Assert all leaf expressions have results and no evaluations
                 Assert.IsTrue(evaluation.HasResults);
                 Assert.AreEqual(0, evaluation.Evaluations.Count());
-                Assert.AreEqual(1, evaluation.Results.Count());
             }
         }
 
@@ -146,14 +142,14 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
             var mockLeafExpression1 = new MockExpression(new ExpressionCommonProperties { Path = firstExpressionPass.HasValue ? evaluatedPath : notEvaluatedPath })
             {
                 EvaluationCallback = pathResolver => firstExpressionPass.HasValue
-                        ? new[] { new JsonRuleEvaluation(null, firstExpressionPass.Value, new[] { new JsonRuleResult { Passed = firstExpressionPass.Value } }) }
+                        ? new[] { new JsonRuleEvaluation(null, firstExpressionPass.Value, new JsonRuleResult { Passed = firstExpressionPass.Value }) }
                         : Enumerable.Empty<JsonRuleEvaluation>()
             };
 
             var mockLeafExpression2 = new MockExpression(new ExpressionCommonProperties { Path = secondExpressionPass.HasValue ? evaluatedPath : notEvaluatedPath })
             {
                 EvaluationCallback = pathResolver => secondExpressionPass.HasValue
-                        ? new[] { new JsonRuleEvaluation(null, secondExpressionPass.Value, new[] { new JsonRuleResult { Passed = secondExpressionPass.Value } }) }
+                        ? new[] { new JsonRuleEvaluation(null, secondExpressionPass.Value, new JsonRuleResult { Passed = secondExpressionPass.Value }) }
                         : Enumerable.Empty<JsonRuleEvaluation>()
             };
 

--- a/src/Analyzer.JsonRuleEngine.UnitTests/TestUtilities.cs
+++ b/src/Analyzer.JsonRuleEngine.UnitTests/TestUtilities.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions;
 using Microsoft.Azure.Templates.Analyzer.Types;
@@ -35,24 +36,17 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.UnitTests
         /// </summary>
         internal class MockExpression : Expression
         {
-            public Func<IJsonPathResolver, JsonRuleEvaluation> EvaluationCallback { get; set; }
-            public Func<IJsonPathResolver, JsonRuleResult> ResultsCallback { get; set; }
+            public Func<IJsonPathResolver, IEnumerable<JsonRuleEvaluation>> EvaluationCallback { get; set; }
 
             public MockExpression(ExpressionCommonProperties commonProperties)
                 : base(commonProperties)
             { }
 
             /// <summary>
-            /// Calls <see cref="Expression.EvaluateInternal(IJsonPathResolver, ILineNumberResolver, Func{IJsonPathResolver, JsonRuleEvaluation})"/> with <see cref="EvaluationCallback"/>,
-            /// or <see cref="Expression.EvaluateInternal(IJsonPathResolver, ILineNumberResolver, Func{IJsonPathResolver, JsonRuleResult})"/> with <see cref="ResultsCallback"/>.
-            /// <see cref="ResultsCallback"/> is used if it is not null.  Otherwise, <see cref="EvaluationCallback"/> is used.
+            /// Calls <see cref="Expression.EvaluateInternal(IJsonPathResolver, Func{IJsonPathResolver, IEnumerable{JsonRuleEvaluation}})"/> with <see cref="EvaluationCallback"/>.
             /// </summary>
-            public override JsonRuleEvaluation Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver lineNumberResolver)
-            {
-                return ResultsCallback != null
-                    ? base.EvaluateInternal(jsonScope, ResultsCallback)
-                    : base.EvaluateInternal(jsonScope, EvaluationCallback);
-            }
+            public override IEnumerable<JsonRuleEvaluation> Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver lineNumberResolver)
+                => base.EvaluateInternal(jsonScope, EvaluationCallback);
         }
     }
 }

--- a/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Operators;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
@@ -38,8 +39,8 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
         /// <param name="jsonScope">The json path to evaluate.</param>
         /// <param name="jsonLineNumberResolver">An <see cref="ILineNumberResolver"/> to
         /// map JSON paths in the returned evaluation to the line number in the JSON evaluated.</param>
-        /// <returns>A <see cref="JsonRuleEvaluation"/> with the result of the evaluation.</returns>
-        public override JsonRuleEvaluation Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver jsonLineNumberResolver)
+        /// <returns>An <see cref="IEnumerable{JsonRuleEvaluation}"/> with the results of the evaluation.</returns>
+        public override IEnumerable<JsonRuleEvaluation> Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver jsonLineNumberResolver)
         {
             return EvaluateInternal(jsonScope, scope =>
             {
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
                     Expression = this
                 };
 
-                return result;
+                return new JsonRuleEvaluation(this, result.Passed, new[] { result });
             });
         }
     }

--- a/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/LeafExpression.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
                     Expression = this
                 };
 
-                return new JsonRuleEvaluation(this, result.Passed, new[] { result });
+                return new JsonRuleEvaluation(this, result.Passed, result);
             });
         }
     }

--- a/src/Analyzer.JsonRuleEngine/Expressions/NotExpression.cs
+++ b/src/Analyzer.JsonRuleEngine/Expressions/NotExpression.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 
@@ -34,15 +35,10 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine.Expressions
         /// <param name="jsonScope">The json to evaluate.</param>
         /// <param name="jsonLineNumberResolver">An <see cref="ILineNumberResolver"/> to
         /// map JSON paths in the returned evaluation to the line number in the JSON evaluated.</param>
-        /// <returns>A <see cref="JsonRuleEvaluation"/> with the results of the evaluation.</returns>
-        public override JsonRuleEvaluation Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver jsonLineNumberResolver)
+        /// <returns>An <see cref="IEnumerable{JsonRuleEvaluation}"/> with the results of the evaluation.</returns>
+        public override IEnumerable<JsonRuleEvaluation> Evaluate(IJsonPathResolver jsonScope, ILineNumberResolver jsonLineNumberResolver)
         {
-            return EvaluateInternal(jsonScope, scope =>
-            {
-                var evaluation = ExpressionToNegate.Evaluate(scope, jsonLineNumberResolver);
-
-                return evaluation;
-            });
+            return EvaluateInternal(jsonScope, scope => ExpressionToNegate.Evaluate(scope, jsonLineNumberResolver));
         }
     }
 }

--- a/src/Analyzer.JsonRuleEngine/JsonRuleEngine.cs
+++ b/src/Analyzer.JsonRuleEngine/JsonRuleEngine.cs
@@ -58,16 +58,19 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         {
             foreach (RuleDefinition rule in RuleDefinitions)
             {
-                JsonRuleEvaluation evaluation = rule.Expression.Evaluate(
+                var evaluations = rule.Expression.Evaluate(
                     new JsonPathResolver(
                         templateContext.ExpandedTemplate,
                         templateContext.ExpandedTemplate.Path),
                     this.BuildLineNumberResolver(templateContext));
 
-                 evaluation.RuleDefinition = rule;
-                 evaluation.FileIdentifier = templateContext.TemplateIdentifier;
-                    
-                yield return evaluation;
+                foreach (var evaluation in evaluations)
+                {
+                    evaluation.RuleDefinition = rule;
+                    evaluation.FileIdentifier = templateContext.TemplateIdentifier;
+
+                    yield return evaluation;
+                }
             }
         }
 

--- a/src/Analyzer.JsonRuleEngine/JsonRuleEvaluation.cs
+++ b/src/Analyzer.JsonRuleEngine/JsonRuleEvaluation.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         }
 
         /// <summary>
-        /// Creates an <see cref="JsonRuleEvaluation"/> that represents a structured expression.
+        /// Creates a <see cref="JsonRuleEvaluation"/> that represents a structured expression.
         /// </summary>
         /// <param name="expression">The expression associated with this evaluation</param>
         /// <param name="passed">Determines whether or not the rule for this evaluation passed.</param>
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         }
 
         /// <summary>
-        /// Creates an <see cref="JsonRuleEvaluation"/> that represents a leaf expression.
+        /// Creates a <see cref="JsonRuleEvaluation"/> that represents a leaf expression.
         /// </summary>
         /// <param name="expression">The expression associated with this evaluation</param>
         /// <param name="passed">Determines whether or not the rule for this evaluation passed.</param>

--- a/src/Analyzer.JsonRuleEngine/JsonRuleEvaluation.cs
+++ b/src/Analyzer.JsonRuleEngine/JsonRuleEvaluation.cs
@@ -14,17 +14,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
     /// <inheritdoc/>
     internal class JsonRuleEvaluation : IEvaluation
     {
-        private IEnumerable<IResult> resultsEvaluatedTrue;
-        private IEnumerable<IResult> resultsEvaluatedFalse;
-
         private IEnumerable<IEvaluation> evaluationsEvaluatedTrue;
         private IEnumerable<IEvaluation> evaluationsEvaluatedFalse;
 
         private IEnumerable<IEvaluation> evaluations;
-        private IEnumerable<IResult> results;
+        private IResult directResult;
 
         private List<IEvaluation> cachedEvaluations;
-        private List<IResult> cachedResults;
 
         /// <summary>
         /// Gets or sets the JSON rule this evaluation is for.
@@ -54,41 +50,16 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         /// </summary>
         internal Expression Expression { get; set; }
 
-        public IEnumerable<IResult> Results
-        {
-            get => cachedResults ??= results.ToList();
-        }
+        public IResult Result => directResult;
 
-        public IEnumerable<IEvaluation> Evaluations
-        {
-            get => cachedEvaluations ??= evaluations.ToList();
-        }
+        public IEnumerable<IEvaluation> Evaluations => cachedEvaluations ??= evaluations.ToList();
 
         /// <summary>
         /// Whether or not there are any results associated with this <see cref="JsonRuleEvaluation"/>.
         /// </summary>
-        /// <returns>True if there are any results in this <see cref="JsonRuleEvaluation"/> or a sub-<see cref="JsonRuleEvaluation"/>.
+        /// <returns>True if there is a result in this <see cref="JsonRuleEvaluation"/> or in any sub-<see cref="JsonRuleEvaluation"/>.
         /// False otherwise.</returns>
-        public bool HasResults
-        {
-            get => Results.Any() || Evaluations.Any(e => e.HasResults);
-        }
-
-        /// <summary>
-        /// Gets the collections of results evaluated to true from this evaluation.
-        /// </summary>
-        public IEnumerable<IResult> ResultsEvaluatedTrue
-        { 
-            get => resultsEvaluatedTrue ??= Results.ToList().FindAll(r => r.Passed);
-        }
-
-        /// <summary>
-        /// Gets the collections of results evaluated to false from this evaluation.
-        /// </summary>
-        public IEnumerable<IResult> ResultsEvaluatedFalse
-        {
-            get => resultsEvaluatedFalse ??= Results.ToList().FindAll(r => !r.Passed);
-        }
+        public bool HasResults => Result != null || Evaluations.Any(e => e.HasResults);
 
         /// <summary>
         /// Gets the collections of evaluations evaluated to true from this evaluation.
@@ -115,7 +86,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         public JsonRuleEvaluation(Expression expression, bool passed, IEnumerable<JsonRuleEvaluation> evaluations)
         {
             this.evaluations = evaluations ?? throw new ArgumentNullException(nameof(evaluations));
-            (this.Expression, this.Passed, this.results) = (expression, passed, Enumerable.Empty<IResult>());
+            (this.Expression, this.Passed, this.directResult) = (expression, passed, null);
         }
 
         /// <summary>
@@ -123,10 +94,10 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.JsonEngine
         /// </summary>
         /// <param name="expression">The expression associated with this evaluation</param>
         /// <param name="passed">Determines whether or not the rule for this evaluation passed.</param>
-        /// <param name="results"><see cref="IEnumerable"/> of results.</param>
-        public JsonRuleEvaluation(Expression expression, bool passed, IEnumerable<JsonRuleResult> results)
+        /// <param name="result">The result of a leaf evaluation.</param>
+        public JsonRuleEvaluation(Expression expression, bool passed, JsonRuleResult result)
         {
-            this.results = results ?? throw new ArgumentNullException(nameof(results));
+            this.directResult = result ?? throw new ArgumentNullException(nameof(result));
             (this.Expression, this.Passed, this.evaluations) = (expression, passed, Enumerable.Empty<IEvaluation>());
         }
     }

--- a/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
+++ b/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
@@ -74,18 +74,20 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
 
             var evaluations = powerShellRuleEngine.AnalyzeTemplate(templateContext);
 
-            Assert.AreEqual(1, evaluations.Count());
-            Assert.IsFalse(evaluations.First().Passed);
+            var evaluationsList = evaluations.ToList();
+            Assert.AreEqual(2, evaluationsList.Count);
 
-            var resultsList = evaluations.First().Results.ToList();
+            foreach (var evaluation in evaluationsList)
+            {
+                Assert.IsFalse(evaluation.Passed);
 
-            Assert.AreEqual(2, resultsList.Count);
+                var resultsList = evaluation.Results.ToList();
+                Assert.AreEqual(1, resultsList.Count);
+                Assert.IsFalse(resultsList[0].Passed);
+            }
 
-            Assert.IsFalse(resultsList[0].Passed);
-            Assert.IsFalse(resultsList[1].Passed);
-
-            Assert.AreEqual(9, resultsList[0].LineNumber);
-            Assert.AreEqual(13, resultsList[1].LineNumber);
+            Assert.AreEqual(9, evaluationsList[0].Results.First().LineNumber);
+            Assert.AreEqual(13, evaluationsList[1].Results.First().LineNumber);
         }
 
         [TestMethod]

--- a/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
+++ b/src/Analyzer.PowerShellRuleEngine.UnitTests/PowerShellRuleEngineTests.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Powershell = System.Management.Automation.PowerShell; // There's a conflict between this class name and a namespace
-
 namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTests
 {
     [TestClass]
@@ -50,8 +48,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
                 else
                 {
                     Assert.IsTrue(evaluation.HasResults);
-                    Assert.AreEqual(1, evaluation.Results.Count());
-                    Assert.IsFalse(evaluation.Results.First().Passed);
+                    Assert.IsFalse(evaluation.Result.Passed);
 
                     failedEvaluations.Add(evaluation);
                 }
@@ -62,7 +59,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
             Assert.AreEqual(failedEvaluations.Count, lineNumbers.Length);
             for (int errorNumber = 0; errorNumber < lineNumbers.Length; errorNumber++)
             {
-                Assert.AreEqual(lineNumbers[errorNumber], failedEvaluations[errorNumber].Results.First().LineNumber);
+                Assert.AreEqual(lineNumbers[errorNumber], failedEvaluations[errorNumber].Result.LineNumber);
                 Assert.IsFalse(failedEvaluations[errorNumber].RuleDescription.Contains(" on line: "));
             }
         }
@@ -80,14 +77,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
             foreach (var evaluation in evaluationsList)
             {
                 Assert.IsFalse(evaluation.Passed);
-
-                var resultsList = evaluation.Results.ToList();
-                Assert.AreEqual(1, resultsList.Count);
-                Assert.IsFalse(resultsList[0].Passed);
+                Assert.IsFalse(evaluation.Result.Passed);
             }
 
-            Assert.AreEqual(9, evaluationsList[0].Results.First().LineNumber);
-            Assert.AreEqual(13, evaluationsList[1].Results.First().LineNumber);
+            Assert.AreEqual(9, evaluationsList[0].Result.LineNumber);
+            Assert.AreEqual(13, evaluationsList[1].Result.LineNumber);
         }
 
         [TestMethod]
@@ -104,11 +98,8 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine.UnitTe
             Assert.IsFalse(evaluationsList[0].Passed);
             Assert.IsFalse(evaluationsList[1].Passed);
 
-            Assert.AreEqual(1, evaluationsList[0].Results.Count());
-            Assert.AreEqual(1, evaluationsList[1].Results.Count());
-
-            Assert.IsFalse(evaluationsList[0].Results.First().Passed);
-            Assert.IsFalse(evaluationsList[1].Results.First().Passed);
+            Assert.IsFalse(evaluationsList[0].Result.Passed);
+            Assert.IsFalse(evaluationsList[1].Result.Passed);
 
             Assert.AreEqual(evaluationsList[0].RuleId, evaluationsList[1].RuleId);
             Assert.AreNotEqual(evaluationsList[0].RuleDescription, evaluationsList[1].RuleDescription);

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 
                     foreach (int lineNumber in uniqueError.Value)
                     {
-                        evaluations.Add(new PowerShellRuleEvaluation(ruleId, ruleDescription, false, new[] { new PowerShellRuleResult(false, lineNumber) }));
+                        evaluations.Add(new PowerShellRuleEvaluation(ruleId, ruleDescription, false, new PowerShellRuleResult(false, lineNumber)));
                     }
                 }
             }

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -103,15 +103,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 
                 foreach (KeyValuePair<string, SortedSet<int>> uniqueError in uniqueErrors)
                 {
-                    var evaluationResults = new List<PowerShellRuleResult>();
-                    foreach (int lineNumber in uniqueError.Value)
-                    {
-                        evaluationResults.Add(new PowerShellRuleResult(false, lineNumber));
-                    }
-
                     var ruleId = (executionResult.Name as string)?.Replace(" ", "") ?? string.Empty;
                     var ruleDescription = executionResult.Name + ". " + uniqueError.Key;
-                    evaluations.Add(new PowerShellRuleEvaluation(ruleId, ruleDescription, false, evaluationResults));
+
+                    foreach (int lineNumber in uniqueError.Value)
+                    {
+                        evaluations.Add(new PowerShellRuleEvaluation(ruleId, ruleDescription, false, new[] { new PowerShellRuleResult(false, lineNumber) }));
+                    }
                 }
             }
 

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 
                 foreach (KeyValuePair<string, SortedSet<int>> uniqueError in uniqueErrors)
                 {
-                    var ruleId = (executionResult.Name as string)?.Replace(" ", "") ?? string.Empty;
+                    var ruleId = (executionResult.Name as string)?.Replace(" ", "");
+                    ruleId = !String.IsNullOrEmpty(ruleId) ? ruleId : "TTK";
                     var ruleDescription = executionResult.Name + ". " + uniqueError.Key;
 
                     foreach (int lineNumber in uniqueError.Value)

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEvaluation.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEvaluation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Templates.Analyzer.Types;
@@ -11,6 +10,9 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
     /// <inheritdoc/>
     public class PowerShellRuleEvaluation : IEvaluation
     {
+        private IEnumerable<IEvaluation> evaluations;
+        private IResult directResult;
+
         /// <inheritdoc/>
         public string RuleId { get; }
 
@@ -30,16 +32,13 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
         public bool Passed { get; }
 
         /// <inheritdoc/>
-        public IEnumerable<IEvaluation> Evaluations { get; }
+        public IEnumerable<IEvaluation> Evaluations => evaluations;
 
         /// <inheritdoc/>
-        public IEnumerable<IResult> Results { get; }
+        public IResult Result => directResult;
 
         /// <inheritdoc/>
-        public bool HasResults
-        {
-            get => Results.Any();
-        }
+        public bool HasResults => Result != null || Evaluations.Any(e => e.HasResults);
 
         /// <summary>
         /// Creates an <see cref="PowerShellRuleEvaluation"/> that describes the evaluation of a PowerShell rule against an ARM template.
@@ -47,15 +46,15 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
         /// <param name="ruleId">The id of the rule associated with this evaluation.</param>
         /// <param name="ruleDescription">The description of the rule associated with this evaluation.</param>
         /// <param name="passed">Determines whether or not the rule for this evaluation passed.</param>
-        /// <param name="results"><see cref="IEnumerable"/> of the results.</param>
-        public PowerShellRuleEvaluation(string ruleId, string ruleDescription, bool passed, IEnumerable<PowerShellRuleResult> results)
+        /// <param name="result">The result of the evaluation.</param>
+        public PowerShellRuleEvaluation(string ruleId, string ruleDescription, bool passed, PowerShellRuleResult result)
         {
             RuleId = ruleId;
             RuleDescription = ruleDescription;
             Recommendation = string.Empty;
             Passed = passed;
-            Results = results;
-            Evaluations = new List<IEvaluation>();
+            this.directResult = result;
+            this.evaluations = new List<IEvaluation>();
             HelpUri = "https://github.com/Azure/arm-ttk";
         }
     }

--- a/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
@@ -51,19 +51,21 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             outputString.Should().BeEquivalentTo(expected.ToString());
         }
 
-        private string GetLineNumbers(Types.IEvaluation evaluation)
+        private string GetLineNumbers(Types.IEvaluation evaluation, HashSet<int> failedLines = null)
         {
+            failedLines ??= new HashSet<int>();
             var resultString = new StringBuilder();
             if (!evaluation.Passed)
             {
-                if (!evaluation.Result?.Passed ?? false)
+                if ((!evaluation.Result?.Passed ?? false) && !failedLines.Any(l => l == evaluation.Result.LineNumber))
                 {
+                    failedLines.Add(evaluation.Result.LineNumber);
                     resultString.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}Line: {evaluation.Result.LineNumber}");
                 }
 
                 foreach (var innerEvaluation in evaluation.Evaluations)
                 {
-                    resultString.Append(GetLineNumbers(innerEvaluation));
+                    resultString.Append(GetLineNumbers(innerEvaluation, failedLines));
                 }
             }
             return resultString.ToString();

--- a/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
@@ -15,22 +15,21 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
     [TestClass]
     public class ConsoleReportWriterTests
     {
-        [TestMethod]
-        public void WriteResults_Evalutions_ReturnExpectedSarifLog()
+        [DataTestMethod]
+        [DynamicData("UnitTestCases", typeof(TestCases), DynamicDataSourceType.Property, DynamicDataDisplayName = "GetTestCaseName", DynamicDataDisplayNameDeclaringType = typeof(TestCases))]
+        public void WriteResults_Evalutions_ReturnExpectedSarifLog(string _, MockEvaluation[] evaluations)
         {
             var templateFilePath = new FileInfo(@"C:\Users\User\Azure\AppServices.json");
-            foreach (var evaluations in TestCases.UnitTestCases)
-            {
-                var output = new StringWriter();
-                Console.SetOut(output);
-                using (var writer = new ConsoleReportWriter())
-                {
-                    writer.WriteResults(evaluations, (FileInfoBase)templateFilePath);
-                }
 
-                // assert
-                AssertConsoleLog(output, evaluations, templateFilePath);
+            var output = new StringWriter();
+            Console.SetOut(output);
+            using (var writer = new ConsoleReportWriter())
+            {
+                writer.WriteResults(evaluations, (FileInfoBase)templateFilePath);
             }
+
+            // assert
+            AssertConsoleLog(output, evaluations, templateFilePath);
         }
 
         private void AssertConsoleLog(StringWriter output, IEnumerable<Types.IEvaluation> testcases, FileInfo templateFilePath)

--- a/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             var resultString = new StringBuilder();
             if (!evaluation.Passed)
             {
-                foreach (var result in evaluation.Results.Where(r => !r.Passed))
+                if (!evaluation.Result?.Passed ?? false)
                 {
-                    resultString.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}Line: {result.LineNumber}");
+                    resultString.Append($"{ConsoleReportWriter.TwiceIndentedNewLine}Line: {evaluation.Result.LineNumber}");
                 }
 
                 foreach (var innerEvaluation in evaluation.Evaluations)

--- a/src/Analyzer.Reports.UnitTests/SarifReportWriterE2ETests.cs
+++ b/src/Analyzer.Reports.UnitTests/SarifReportWriterE2ETests.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             string ruleId = "TA-000028";
             List<List<int>> expectedLinesForRun = new List<List<int>>
             {
-                new List<int> { 146, 147, 148, 148 },
-                new List<int> { 206, 207, 208, 208 }
+                new List<int> { 146, 147, 148 },
+                new List<int> { 206, 207, 208 }
             };
 
             string artifactUriString = templateFilePath.Name;
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                     file: expectedSecondTemplateFilePathInSarif,
                     uriBase: secondTemplateUsesRelativePath ? SarifReportWriter.UriBaseIdString : null,
                     lines: new List<List<int>> {
-                        new List<int> { 146, 147, 148, 148 },
-                        new List<int> { 206, 207, 208, 208 }
+                        new List<int> { 146, 147, 148 },
+                        new List<int> { 206, 207, 208 }
                     })
                 }
             };

--- a/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
@@ -124,7 +124,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                 foreach (var evaluation in evaluations)
                 {
                     var rule = rules.SingleOrDefault(r => r.Id.Equals(evaluation.RuleId));
-                    if (evaluation.Passed) rule.Should().BeNull();
+                    if (evaluation.Passed)
+                    {
+                        rule.Should().BeNull();
+                    }
                     else
                     {
                         rule.Should().NotBeNull();

--- a/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
 
         private void TraverseResults(IList<Types.IResult> results, Types.IEvaluation evaluation)
         {
-            if (!evaluation.Result?.Passed ?? false)
+            if ((!evaluation.Result?.Passed ?? false) && !results.Any(r => r.LineNumber == evaluation.Result.LineNumber))
             {
                 results.Add(evaluation.Result);
             }

--- a/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/SarifReportWriterTests.cs
@@ -18,23 +18,22 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
     [TestClass]
     public class SarifReportWriterTests
     {
-        [TestMethod]
-        public void WriteResults_Evalutions_ReturnExpectedSarifLog()
+        [DataTestMethod]
+        [DynamicData("UnitTestCases", typeof(TestCases), DynamicDataSourceType.Property, DynamicDataDisplayName = "GetTestCaseName", DynamicDataDisplayNameDeclaringType = typeof(TestCases))]
+        public void WriteResults_Evalutions_ReturnExpectedSarifLog(string _, MockEvaluation[] evaluations)
         {
             string currentFolder = Path.Combine(Directory.GetCurrentDirectory(), "testRepo");
             var templateFilePath = new FileInfo(Path.Combine(currentFolder, "AppServices.json"));
-            foreach (var evaluations in TestCases.UnitTestCases)
+            
+            var memStream = new MemoryStream();
+            using (var writer = SetupWriter(memStream))
             {
-                var memStream = new MemoryStream();
-                using (var writer = SetupWriter(memStream))
-                {
-                    writer.WriteResults(evaluations, (FileInfoBase)templateFilePath);
-                }
-
-                // assert
-                SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(ASCIIEncoding.UTF8.GetString(memStream.ToArray()));
-                AssertSarifLog(sarifLog, evaluations, templateFilePath);
+                writer.WriteResults(evaluations, (FileInfoBase)templateFilePath);
             }
+
+            // assert
+            SarifLog sarifLog = JsonConvert.DeserializeObject<SarifLog>(Encoding.UTF8.GetString(memStream.ToArray()));
+            AssertSarifLog(sarifLog, evaluations, templateFilePath);
         }
 
         private SarifReportWriter SetupWriter(Stream stream)

--- a/src/Analyzer.Reports.UnitTests/TestCases.cs
+++ b/src/Analyzer.Reports.UnitTests/TestCases.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
         {
             new object[]
             {
-                "Single evaluation with single failed result",
+                "Single evaluation with failed result",
                 new []
                 {
                     new MockEvaluation
@@ -26,38 +26,13 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         HelpUri = "https://domain.com/help",
                         Passed = false,
                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                        Results = new[]
-                        {
-                            new MockResult { Passed = false, LineNumber = 10 }
-                        }
+                        Result = new MockResult { Passed = false, LineNumber = 10 }
                     }
                 }
             },
             new object[]
             {
-                "Single evaluation with multiple failed results",
-                new[]
-                {
-                    new MockEvaluation
-                    {
-                        RuleId = "TEST-000001",
-                        RuleDescription = "Test rule 0000001",
-                        Recommendation = "Recommendation 0000001",
-                        HelpUri = "https://domain.com/help",
-                        Passed = false,
-                        Evaluations = Enumerable.Empty<MockEvaluation>(),
-                        Results = new[]
-                        {
-                            new MockResult { Passed = false, LineNumber = 10 },
-                            new MockResult { Passed = false, LineNumber = 22 },
-                            new MockResult { Passed = false, LineNumber = 65 },
-                        }
-                    }
-                }
-            },
-            new object[]
-            {
-                "Multiple evaluations with multiple failed results",
+                "Multiple evaluations with failed results, different rules",
                 new []
                 {
                     new MockEvaluation
@@ -68,12 +43,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         HelpUri = "https://domain.com/help",
                         Passed = false,
                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                        Results = new[]
-                        {
-                            new MockResult { Passed = false, LineNumber = 10 },
-                            new MockResult { Passed = false, LineNumber = 22 },
-                            new MockResult { Passed = false, LineNumber = 65 },
-                        }
+                        Result = new MockResult { Passed = false, LineNumber = 65 }
                     },
                     new MockEvaluation
                     {
@@ -83,17 +53,50 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         HelpUri = "https://domain.com/help",
                         Passed = false,
                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                        Results = new[]
-                        {
-                            new MockResult { Passed = false, LineNumber = 120 },
-                            new MockResult { Passed = false, LineNumber = 632 },
-                        }
+                        Result = new MockResult { Passed = false, LineNumber = 120 }
                     }
                 }
             },
             new object[]
             {
-                "Single nested evaluation",
+                "Multiple evaluations with failed results, duplicate rules",
+                new []
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Result = new MockResult { Passed = false, LineNumber = 65 }
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Result = new MockResult { Passed = false, LineNumber = 65 }
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Result = new MockResult { Passed = false, LineNumber = 120 }
+                    }
+                }
+            },
+            new object[]
+            {
+                "Single evaluation with nested evaluations",
                 new[]
                 {
                     new MockEvaluation
@@ -103,12 +106,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000001",
                         HelpUri = "https://domain.com/help",
                         Passed = false,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = false,
                                 Evaluations = new []
                                 {
@@ -116,10 +117,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = false,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 9 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 9 }
                                     }
                                 }
                             },
@@ -127,11 +125,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                             {
                                 Passed = false,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = false, LineNumber = 23 },
-                                    new MockResult { Passed = false, LineNumber = 117 },
-                                },
+                                Result = new MockResult { Passed = false, LineNumber = 117 }
                             },
                         },
                     }
@@ -149,12 +143,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000001",
                         HelpUri = "https://domain.com/help",
                         Passed = false,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = false,
                                 Evaluations = new []
                                 {
@@ -162,10 +154,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = false,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 9 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 9 }
                                     }
                                 }
                             },
@@ -173,11 +162,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                             {
                                 Passed = false,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = false, LineNumber = 23 },
-                                    new MockResult { Passed = false, LineNumber = 117 },
-                                },
+                                Result = new MockResult { Passed = false, LineNumber = 23 }
                             },
                         },
                     },
@@ -188,22 +173,16 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000002",
                         HelpUri = "https://domain.com/help#0000002",
                         Passed = false,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
                                 Passed = false,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = false, LineNumber = 25 },
-                                    new MockResult { Passed = false, LineNumber = 72 },
-                                },
+                                Result = new MockResult { Passed = false, LineNumber = 25 }
                             },
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = false,
                                 Evaluations = new []
                                 {
@@ -211,21 +190,13 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = false,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 130 },
-                                            new MockResult { Passed = false, LineNumber = 199 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
                                     },
                                     new MockEvaluation
                                     {
                                         Passed = false,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 245 },
-                                            new MockResult { Passed = false, LineNumber = 618 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 245 }
                                     }
                                 }
                             },
@@ -235,7 +206,115 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             },
             new object[]
             {
-
+                "Multiple nested evaluations with duplicate rules",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 9 }
+                                    }
+                                }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 23 }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 245 }
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 245 }
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+            new object[]
+            {
                 "Multiple nested evaluations with mixed pass/fail results",
                 new[]
                 {
@@ -246,12 +325,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000001",
                         HelpUri = "https://domain.com/help",
                         Passed = false,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = false,
                                 Evaluations = new []
                                 {
@@ -259,10 +336,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = true,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 9 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 9 }
                                     }
                                 }
                             },
@@ -270,11 +344,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                             {
                                 Passed = false,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = false, LineNumber = 23 },
-                                    new MockResult { Passed = false, LineNumber = 117 },
-                                },
+                                Result = new MockResult { Passed = false, LineNumber = 117 }
                             },
                         },
                     },
@@ -285,22 +355,16 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000002",
                         HelpUri = "https://domain.com/help#0000002",
                         Passed = false,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
                                 Passed = true,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = true, LineNumber = 25 },
-                                    new MockResult { Passed = true, LineNumber = 72 },
-                                },
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
                             },
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = false,
                                 Evaluations = new []
                                 {
@@ -308,21 +372,49 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = true,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 130 },
-                                            new MockResult { Passed = false, LineNumber = 199 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
                                     },
                                     new MockEvaluation
                                     {
                                         Passed = false,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = false, LineNumber = 245 },
-                                            new MockResult { Passed = false, LineNumber = 618 },
-                                        }
+                                        Result = new MockResult { Passed = false, LineNumber = 618 }
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000003",
+                        RuleDescription = "Test rule 0000003",
+                        Recommendation = "Recommendation 0000003",
+                        HelpUri = "https://domain.com/help#0000003",
+                        Passed = true,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = true, LineNumber = 618 }
                                     }
                                 }
                             },
@@ -332,7 +424,151 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
             },
             new object[]
             {
-
+                "Multiple nested evaluations with mixed pass/fail results and repeated rules",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 9 }
+                                    }
+                                }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 117 }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 618 }
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 618 }
+                                    }
+                                }
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000003",
+                        RuleDescription = "Test rule 0000003",
+                        Recommendation = "Recommendation 0000003",
+                        HelpUri = "https://domain.com/help#0000003",
+                        Passed = true,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = false, LineNumber = 130 }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Result = new MockResult { Passed = true, LineNumber = 618 }
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+            new object[]
+            {
                 "Multiple nested evaluations with all passed results",
                 new[]
                 {
@@ -343,12 +579,10 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000001",
                         HelpUri = "https://domain.com/help",
                         Passed = true,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = true,
                                 Evaluations = new []
                                 {
@@ -356,10 +590,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = true,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = true, LineNumber = 9 },
-                                        }
+                                        Result = new MockResult { Passed = true, LineNumber = 9 }
                                     }
                                 }
                             },
@@ -367,11 +598,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                             {
                                 Passed = true,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = true, LineNumber = 23 },
-                                    new MockResult { Passed = true, LineNumber = 117 },
-                                },
+                                Result = new MockResult { Passed = true, LineNumber = 117 }
                             },
                         },
                     },
@@ -382,22 +609,16 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         Recommendation = "Recommendation 0000002",
                         HelpUri = "https://domain.com/help#0000002",
                         Passed = true,
-                        Results = Enumerable.Empty<MockResult>(),
                         Evaluations = new []
                         {
                             new MockEvaluation
                             {
                                 Passed = true,
                                 Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                Results = new []
-                                {
-                                    new MockResult { Passed = true, LineNumber = 25 },
-                                    new MockResult { Passed = true, LineNumber = 72 },
-                                },
+                                Result = new MockResult { Passed = true, LineNumber = 25 }
                             },
                             new MockEvaluation
                             {
-                                Results = Enumerable.Empty<MockResult>(),
                                 Passed = true,
                                 Evaluations = new []
                                 {
@@ -405,32 +626,11 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                                     {
                                         Passed = true,
                                         Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                        Results = new []
-                                        {
-                                            new MockResult { Passed = true, LineNumber = 130 },
-                                            new MockResult { Passed = true, LineNumber = 199 },
-                                        }
+                                        Result = new MockResult { Passed = true, LineNumber = 130 }
                                     }
                                 }
                             },
                         },
-                    }
-                }
-            },
-            new object[]
-            {
-                "Evaluation without results",
-                new[]
-                {
-                    new MockEvaluation
-                    {
-                        RuleId = "TEST-000001",
-                        RuleDescription = "Test rule 0000001",
-                        Recommendation = "Recommendation 0000001",
-                        HelpUri = "https://domain.com/help",
-                        Passed = false,
-                        Evaluations = Enumerable.Empty<MockEvaluation>(),
-                        Results = Enumerable.Empty<MockResult>(),
                     }
                 }
             }

--- a/src/Analyzer.Reports.UnitTests/TestCases.cs
+++ b/src/Analyzer.Reports.UnitTests/TestCases.cs
@@ -633,6 +633,71 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                         },
                     }
                 }
+            },
+            new object[]
+            {
+                "Evaluations with same line flagged multiple times",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 9 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 9 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 15 }
+                            }
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 45 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 45 }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Result = new MockResult { Passed = false, LineNumber = 50 }
+                            }
+                        }
+                    }
+                }
             }
         }.AsReadOnly();
     }

--- a/src/Analyzer.Reports.UnitTests/TestCases.cs
+++ b/src/Analyzer.Reports.UnitTests/TestCases.cs
@@ -3,408 +3,437 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
 {
     public class TestCases
     {
-        public static IEnumerable<IEnumerable<MockEvaluation>> UnitTestCases = new[]
+        public static string GetTestCaseName(MethodInfo _, object[] testData) => (string)testData[0];
+
+        public static IReadOnlyCollection<object[]> UnitTestCases => new List<object[]>
         {
-            // Single evaluation with single failed result
-            new []
+            new object[]
             {
-                new MockEvaluation
+                "Single evaluation with single failed result",
+                new []
                 {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                    Results = new[]
+                    new MockEvaluation
                     {
-                        new MockResult { Passed = false, LineNumber = 10 }
-                    }
-                }
-            },
-            // Single evaluation with multiple failed results
-            new[]
-            {
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                    Results = new[]
-                    {
-                        new MockResult { Passed = false, LineNumber = 10 },
-                        new MockResult { Passed = false, LineNumber = 22 },
-                        new MockResult { Passed = false, LineNumber = 65 },
-                    }
-                }
-            },
-            // Multiple evaluations with multiple failed results
-            new []
-            {
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                    Results = new[]
-                    {
-                        new MockResult { Passed = false, LineNumber = 10 },
-                        new MockResult { Passed = false, LineNumber = 22 },
-                        new MockResult { Passed = false, LineNumber = 65 },
-                    }
-                },
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000002",
-                    RuleDescription = "Test rule 0000002",
-                    Recommendation = "Recommendation 0000002",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                    Results = new[]
-                    {
-                        new MockResult { Passed = false, LineNumber = 120 },
-                        new MockResult { Passed = false, LineNumber = 632 },
-                    }
-                }
-            },
-            // Single nested evaluation
-            new[]
-            {
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
-                    {
-                        new MockEvaluation
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Results = new[]
                         {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = false,
-                            Evaluations = new []
+                            new MockResult { Passed = false, LineNumber = 10 }
+                        }
+                    }
+                }
+            },
+            new object[]
+            {
+                "Single evaluation with multiple failed results",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Results = new[]
+                        {
+                            new MockResult { Passed = false, LineNumber = 10 },
+                            new MockResult { Passed = false, LineNumber = 22 },
+                            new MockResult { Passed = false, LineNumber = 65 },
+                        }
+                    }
+                }
+            },
+            new object[]
+            {
+                "Multiple evaluations with multiple failed results",
+                new []
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Results = new[]
+                        {
+                            new MockResult { Passed = false, LineNumber = 10 },
+                            new MockResult { Passed = false, LineNumber = 22 },
+                            new MockResult { Passed = false, LineNumber = 65 },
+                        }
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Results = new[]
+                        {
+                            new MockResult { Passed = false, LineNumber = 120 },
+                            new MockResult { Passed = false, LineNumber = 632 },
+                        }
+                    }
+                }
+            },
+            new object[]
+            {
+                "Single nested evaluation",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
                             {
-                                new MockEvaluation
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = false,
+                                Evaluations = new []
                                 {
-                                    Passed = false,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
+                                    new MockEvaluation
                                     {
-                                        new MockResult { Passed = false, LineNumber = 9 },
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 9 },
+                                        }
                                     }
                                 }
-                            }
-                        },
-                        new MockEvaluation
-                        {
-                            Passed = false,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
-                            {
-                                new MockResult { Passed = false, LineNumber = 23 },
-                                new MockResult { Passed = false, LineNumber = 117 },
                             },
-                        },
-                    },
-                }
-            },
-            // Multiple nested evaluations
-            new[]
-            {
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
-                    {
-                        new MockEvaluation
-                        {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = false,
-                            Evaluations = new []
+                            new MockEvaluation
                             {
-                                new MockEvaluation
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
                                 {
-                                    Passed = false,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = false, LineNumber = 9 },
-                                    }
-                                }
-                            }
-                        },
-                        new MockEvaluation
-                        {
-                            Passed = false,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
-                            {
-                                new MockResult { Passed = false, LineNumber = 23 },
-                                new MockResult { Passed = false, LineNumber = 117 },
-                            },
-                        },
-                    },
-                },
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000002",
-                    RuleDescription = "Test rule 0000002",
-                    Recommendation = "Recommendation 0000002",
-                    HelpUri = "https://domain.com/help#0000002",
-                    Passed = false,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
-                    {
-                        new MockEvaluation
-                        {
-                            Passed = false,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
-                            {
-                                new MockResult { Passed = false, LineNumber = 25 },
-                                new MockResult { Passed = false, LineNumber = 72 },
-                            },
-                        },
-                        new MockEvaluation
-                        {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = false,
-                            Evaluations = new []
-                            {
-                                new MockEvaluation
-                                {
-                                    Passed = false,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = false, LineNumber = 130 },
-                                        new MockResult { Passed = false, LineNumber = 199 },
-                                    }
+                                    new MockResult { Passed = false, LineNumber = 23 },
+                                    new MockResult { Passed = false, LineNumber = 117 },
                                 },
-                                new MockEvaluation
-                                {
-                                    Passed = false,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = false, LineNumber = 245 },
-                                        new MockResult { Passed = false, LineNumber = 618 },
-                                    }
-                                }
-                            }
+                            },
                         },
-                    },
+                    }
                 }
             },
-            // Multiple nested evaluations with mixed pass/fail results
-            new[]
+            new object[]
             {
-                new MockEvaluation
+                "Multiple nested evaluations",
+                new[]
                 {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
+                    new MockEvaluation
                     {
-                        new MockEvaluation
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
                         {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = false,
-                            Evaluations = new []
+                            new MockEvaluation
                             {
-                                new MockEvaluation
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = false,
+                                Evaluations = new []
                                 {
-                                    Passed = true,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
+                                    new MockEvaluation
                                     {
-                                        new MockResult { Passed = false, LineNumber = 9 },
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 9 },
+                                        }
                                     }
                                 }
-                            }
-                        },
-                        new MockEvaluation
-                        {
-                            Passed = false,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
-                            {
-                                new MockResult { Passed = false, LineNumber = 23 },
-                                new MockResult { Passed = false, LineNumber = 117 },
                             },
-                        },
-                    },
-                },
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000002",
-                    RuleDescription = "Test rule 0000002",
-                    Recommendation = "Recommendation 0000002",
-                    HelpUri = "https://domain.com/help#0000002",
-                    Passed = false,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
-                    {
-                        new MockEvaluation
-                        {
-                            Passed = true,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
+                            new MockEvaluation
                             {
-                                new MockResult { Passed = true, LineNumber = 25 },
-                                new MockResult { Passed = true, LineNumber = 72 },
-                            },
-                        },
-                        new MockEvaluation
-                        {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = false,
-                            Evaluations = new []
-                            {
-                                new MockEvaluation
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
                                 {
-                                    Passed = true,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = false, LineNumber = 130 },
-                                        new MockResult { Passed = false, LineNumber = 199 },
-                                    }
+                                    new MockResult { Passed = false, LineNumber = 23 },
+                                    new MockResult { Passed = false, LineNumber = 117 },
                                 },
-                                new MockEvaluation
-                                {
-                                    Passed = false,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = false, LineNumber = 245 },
-                                        new MockResult { Passed = false, LineNumber = 618 },
-                                    }
-                                }
-                            }
-                        },
-                    },
-                }
-            },
-            // Multiple nested evaluations with all passed results
-            new[]
-            {
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = true,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
-                    {
-                        new MockEvaluation
-                        {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = true,
-                            Evaluations = new []
-                            {
-                                new MockEvaluation
-                                {
-                                    Passed = true,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
-                                    {
-                                        new MockResult { Passed = true, LineNumber = 9 },
-                                    }
-                                }
-                            }
-                        },
-                        new MockEvaluation
-                        {
-                            Passed = true,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
-                            {
-                                new MockResult { Passed = true, LineNumber = 23 },
-                                new MockResult { Passed = true, LineNumber = 117 },
                             },
                         },
                     },
-                },
-                new MockEvaluation
-                {
-                    RuleId = "TEST-000002",
-                    RuleDescription = "Test rule 0000002",
-                    Recommendation = "Recommendation 0000002",
-                    HelpUri = "https://domain.com/help#0000002",
-                    Passed = true,
-                    Results = Enumerable.Empty<MockResult>(),
-                    Evaluations = new []
+                    new MockEvaluation
                     {
-                        new MockEvaluation
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
                         {
-                            Passed = true,
-                            Evaluations = Enumerable.Empty<MockEvaluation>(),
-                            Results = new []
+                            new MockEvaluation
                             {
-                                new MockResult { Passed = true, LineNumber = 25 },
-                                new MockResult { Passed = true, LineNumber = 72 },
-                            },
-                        },
-                        new MockEvaluation
-                        {
-                            Results = Enumerable.Empty<MockResult>(),
-                            Passed = true,
-                            Evaluations = new []
-                            {
-                                new MockEvaluation
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
                                 {
-                                    Passed = true,
-                                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                                    Results = new []
+                                    new MockResult { Passed = false, LineNumber = 25 },
+                                    new MockResult { Passed = false, LineNumber = 72 },
+                                },
+                            },
+                            new MockEvaluation
+                            {
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
                                     {
-                                        new MockResult { Passed = true, LineNumber = 130 },
-                                        new MockResult { Passed = true, LineNumber = 199 },
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 130 },
+                                            new MockResult { Passed = false, LineNumber = 199 },
+                                        }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 245 },
+                                            new MockResult { Passed = false, LineNumber = 618 },
+                                        }
                                     }
                                 }
-                            }
+                            },
                         },
-                    },
+                    }
                 }
             },
-            // Evaluation without results
-            new[]
+            new object[]
             {
-                new MockEvaluation
+
+                "Multiple nested evaluations with mixed pass/fail results",
+                new[]
                 {
-                    RuleId = "TEST-000001",
-                    RuleDescription = "Test rule 0000001",
-                    Recommendation = "Recommendation 0000001",
-                    HelpUri = "https://domain.com/help",
-                    Passed = false,
-                    Evaluations = Enumerable.Empty<MockEvaluation>(),
-                    Results = Enumerable.Empty<MockResult>(),
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 9 },
+                                        }
+                                    }
+                                }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = false,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
+                                {
+                                    new MockResult { Passed = false, LineNumber = 23 },
+                                    new MockResult { Passed = false, LineNumber = 117 },
+                                },
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = false,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
+                                {
+                                    new MockResult { Passed = true, LineNumber = 25 },
+                                    new MockResult { Passed = true, LineNumber = 72 },
+                                },
+                            },
+                            new MockEvaluation
+                            {
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = false,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 130 },
+                                            new MockResult { Passed = false, LineNumber = 199 },
+                                        }
+                                    },
+                                    new MockEvaluation
+                                    {
+                                        Passed = false,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = false, LineNumber = 245 },
+                                            new MockResult { Passed = false, LineNumber = 618 },
+                                        }
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+            new object[]
+            {
+
+                "Multiple nested evaluations with all passed results",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = true,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = true,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = true, LineNumber = 9 },
+                                        }
+                                    }
+                                }
+                            },
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
+                                {
+                                    new MockResult { Passed = true, LineNumber = 23 },
+                                    new MockResult { Passed = true, LineNumber = 117 },
+                                },
+                            },
+                        },
+                    },
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000002",
+                        RuleDescription = "Test rule 0000002",
+                        Recommendation = "Recommendation 0000002",
+                        HelpUri = "https://domain.com/help#0000002",
+                        Passed = true,
+                        Results = Enumerable.Empty<MockResult>(),
+                        Evaluations = new []
+                        {
+                            new MockEvaluation
+                            {
+                                Passed = true,
+                                Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                Results = new []
+                                {
+                                    new MockResult { Passed = true, LineNumber = 25 },
+                                    new MockResult { Passed = true, LineNumber = 72 },
+                                },
+                            },
+                            new MockEvaluation
+                            {
+                                Results = Enumerable.Empty<MockResult>(),
+                                Passed = true,
+                                Evaluations = new []
+                                {
+                                    new MockEvaluation
+                                    {
+                                        Passed = true,
+                                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                                        Results = new []
+                                        {
+                                            new MockResult { Passed = true, LineNumber = 130 },
+                                            new MockResult { Passed = true, LineNumber = 199 },
+                                        }
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+            new object[]
+            {
+                "Evaluation without results",
+                new[]
+                {
+                    new MockEvaluation
+                    {
+                        RuleId = "TEST-000001",
+                        RuleDescription = "Test rule 0000001",
+                        Recommendation = "Recommendation 0000001",
+                        HelpUri = "https://domain.com/help",
+                        Passed = false,
+                        Evaluations = Enumerable.Empty<MockEvaluation>(),
+                        Results = Enumerable.Empty<MockResult>(),
+                    }
                 }
             }
-        };
+        }.AsReadOnly();
     }
 }

--- a/src/Analyzer.Reports.UnitTests/TestEvaluation.cs
+++ b/src/Analyzer.Reports.UnitTests/TestEvaluation.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Microsoft.Azure.Templates.Analyzer.Types;
 
 namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
 {
-    public class MockEvaluation : Types.IEvaluation
+    public class MockEvaluation : IEvaluation
     {
         public string RuleId { get; set; }
 
@@ -19,14 +20,14 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
 
         public bool Passed { get; set; }
 
-        public IEnumerable<Types.IEvaluation> Evaluations { get; set; }
+        public IEnumerable<IEvaluation> Evaluations { get; set; }
 
-        public IEnumerable<Types.IResult> Results { get; set; }
+        public IResult Result { get; set; }
 
         public bool HasResults { get; set; }
     }
 
-    public class MockResult : Types.IResult
+    public class MockResult : IResult
     {
         public bool Passed { get; set; }
 

--- a/src/Analyzer.Reports/ConsoleReportWriter.cs
+++ b/src/Analyzer.Reports/ConsoleReportWriter.cs
@@ -58,12 +58,9 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
 
             if (!evaluation.Passed)
             {
-                foreach (var result in evaluation.Results)
+                if (!evaluation.Result?.Passed ?? false)
                 {
-                    if (!result.Passed)
-                    {
-                        resultString += $"{TwiceIndentedNewLine}Line: {result.LineNumber}";
-                    }
+                    resultString += $"{TwiceIndentedNewLine}Line: {evaluation.Result.LineNumber}";
                 }
 
                 foreach (var innerEvaluation in evaluation.Evaluations)

--- a/src/Analyzer.Reports/ConsoleReportWriter.cs
+++ b/src/Analyzer.Reports/ConsoleReportWriter.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
+using System.Linq;
+using Microsoft.Azure.Templates.Analyzer.Types;
 
 namespace Microsoft.Azure.Templates.Analyzer.Reports
 {
@@ -37,7 +39,9 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
             {
                 if (!evaluation.Passed)
                 {
-                    string resultString = GenerateResultString(evaluation);
+                    string resultString = string.Concat(
+                        GetFailedLines(evaluation)
+                        .Select(l => $"{TwiceIndentedNewLine}Line: {l}"));
                     var output = $"{IndentedNewLine}{(evaluation.RuleId != "" ? $"{evaluation.RuleId}: " : "")}{evaluation.RuleDescription}" +
                     (!string.IsNullOrWhiteSpace(evaluation.Recommendation) ? $"{TwiceIndentedNewLine}Recommendation: {evaluation.Recommendation}" : "") +
                     $"{TwiceIndentedNewLine}More information: {evaluation.HelpUri}" +
@@ -52,24 +56,21 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
             Console.WriteLine($"{IndentedNewLine}Rules passed: {passedEvaluations}");
         }
 
-        private string GenerateResultString(Types.IEvaluation evaluation)
+        private HashSet<int> GetFailedLines(IEvaluation evaluation, HashSet<int> failedLines = null)
         {
-            string resultString = "";
+            failedLines ??= new HashSet<int>();
 
-            if (!evaluation.Passed)
+            if (!evaluation.Result?.Passed ?? false)
             {
-                if (!evaluation.Result?.Passed ?? false)
-                {
-                    resultString += $"{TwiceIndentedNewLine}Line: {evaluation.Result.LineNumber}";
-                }
-
-                foreach (var innerEvaluation in evaluation.Evaluations)
-                {
-                    resultString += GenerateResultString(innerEvaluation);
-                }
+                failedLines.Add(evaluation.Result.LineNumber);
             }
 
-            return resultString;
+            foreach(var eval in evaluation.Evaluations.Where(e => !e.Passed))
+            {
+                GetFailedLines(eval, failedLines);
+            }
+
+            return failedLines;
         }
 
         /// <inheritdoc/>

--- a/src/Analyzer.Reports/SarifReportWriter.cs
+++ b/src/Analyzer.Reports/SarifReportWriter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
                     RuleId = evaluation.RuleId,
                     Level = GetLevelFromEvaluation(evaluation),
                     Message = new Message { Id = "default" }, // should be customized message for each result 
-                    Locations = ExtractLocations(evaluation, templateFile.Name, isFileInRootPath, new Dictionary<int, List<Location>>()).Values.SelectMany(l => l).ToArray()
+                    Locations = ExtractLocations(evaluation, filePath, isFileInRootPath, new Dictionary<int, List<Location>>()).Values.SelectMany(l => l).ToArray()
                 });
             }
         }

--- a/src/Analyzer.Reports/SarifReportWriter.cs
+++ b/src/Analyzer.Reports/SarifReportWriter.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
 
         private Dictionary<int, List<Location>> ExtractLocations(IEvaluation evaluation, string filePath, bool pathBelongsToRoot, Dictionary<int, List<Location>> locations)
         {
-            foreach (var result in evaluation.Results.Where(r => !r.Passed))
+            if (evaluation.Result != null && !evaluation.Result.Passed)
             {
-                var line = result.LineNumber;
+                var line = evaluation.Result.LineNumber;
                 if (!locations.TryGetValue(line, out List<Location> locationList))
                 {
                     locationList = new List<Location>();

--- a/src/Analyzer.Reports/SarifReportWriter.cs
+++ b/src/Analyzer.Reports/SarifReportWriter.cs
@@ -116,12 +116,12 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
             };
         }
 
-        private ReportingDescriptor ExtractRule(IEvaluation evaluation)
+        private void ExtractRule(IEvaluation evaluation)
         {
-            if (!rulesDictionary.TryGetValue(evaluation.RuleId, out ReportingDescriptor rule))
+            if (!rulesDictionary.ContainsKey(evaluation.RuleId))
             {
                 var hasUri = Uri.TryCreate(evaluation.HelpUri, UriKind.RelativeOrAbsolute, out Uri uri);
-                rule = new ReportingDescriptor
+                rulesDictionary.Add(evaluation.RuleId, new ReportingDescriptor
                 {
                     Id = evaluation.RuleId,
                     // Name = evaluation.RuleId, TBD issue #198
@@ -133,10 +133,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
                         { "default", new MultiformatMessageString { Text = AppendPeriod(evaluation.RuleDescription) } }
                     },
                     DefaultConfiguration = new ReportingConfiguration { Level = GetLevelFromEvaluation(evaluation) }
-                };
-                rulesDictionary.Add(evaluation.RuleId, rule);
+                });
             }
-            return rule;
         }
 
         private Dictionary<int, Location> ExtractLocations(IEvaluation evaluation, string filePath, bool pathBelongsToRoot, Dictionary<int, Location> locations = null)

--- a/src/Analyzer.Types/IEvaluation.cs
+++ b/src/Analyzer.Types/IEvaluation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Types
         /// <summary>
         /// Gets the collections of results from this evaluation.
         /// </summary>
-        public IEnumerable<IResult> Results { get; }
+        public IResult Result { get; }
 
         /// <summary>
         /// Gets wether this evaluation has corresponding results.

--- a/src/Analyzer.Types/IEvaluation.cs
+++ b/src/Analyzer.Types/IEvaluation.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Types
         public IResult Result { get; }
 
         /// <summary>
-        /// Gets wether this evaluation has corresponding results.
+        /// Gets whether this evaluation has corresponding results.
         /// </summary>
         /// <returns>Whether this evaluation has corresponding results</returns>
         public bool HasResults { get; }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!-- Please add an informative description that covers the changes made by the pull request. -->
(Closes #226)

Currently, when a template is analyzed with a particular rule, the outcome of the analysis is returned via a single `Evaluation`, which contains multiple sub-`Evaluation`s within it, representing each location (normally a resource) where the rule failed.  This causes complexity in reporting, since it's not always straightforward how to group results and line numbers into related or distinct failures.

This PR changes how rule `Expressions` return their outcomes - instead of wrapping the entire template analysis into a single `Evaluation` per `Expression`,  `Expression`s will return an `IEnumerable<Evaluation>`, where each `Evaluation` will represent a separate analysis/outcome within the template.  An `Evaluation` can still have nested `Evaluation`s within it for nested `Expression`s within the rule.  This makes it easier for reporting to identify how to group the results.

### Summary of changes
- `Expression`s return `IEnumerable<Evaluation>` instead of single `Evaluation`
- `Expression`s now contain only a single `Result` (not an `Enumerable<Result>`) or nested `Evaluation`s
- `Expression` base class is now greatly simplified - how `Expression`s do their evaluations is consistent everywhere.
  - Side effect: multiple `Evaluation`s from JSON path expansion (for example, wildcard paths, `resourceType` specifications in rules) are no longer explicitly `&&`-ed together - instead, these `Evaluation`s are simply returned as-is, and either combined as appropriate in a higher-level `Expression` (`allOf` or `anyOf` for example) or left alone to become their own outcomes.  I think this is better behavior overall for rules.
- SARIF and Console report writers do some deduplication of line numbers within a top-level `Expression`.  The same line could still be reported multiple times across different top-level `Expression`s (for example, a resource that uses copy loops failing a rule would have a failure for each copy, which all ultimately map back to the same line number).  Improving this will be taken up in a future update (#228).
- Lots of test updates to reflect the new design and behavior.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [x] I have added myself to the 'assignees'.
- [x] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [x] Pull request includes test coverage for the included changes.
