### PR TITLE
Simplify pathing and allow newer versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,7 @@ MigrationBackup/
 
 # Launch settings for Visual Studio
 **/Properties/launchSettings.json
+
+# Ignore PSRule modules
+src/Analyzer.PowerShellRuleEngine/PSRule/
+src/Analyzer.PowerShellRuleEngine/PSRule.Rules.Azure/


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- Updated PSRule paths to find the first version instead of using hardcoded versions.
- Added `-nodeps.psd` to remove requirement to manually change `PSRule.Rules.Azure.psd` file.
- Added line reporting from PSRule.

Tested with PSRule v2.1.0 and PSRule.Rules.Azure v1.15.0.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [ ] I have added myself to the 'assignees'.
- [ ] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [ ] Pull request includes test coverage for the included changes.
