### PR TITLE
Unblock PSRule PowerShell scripts for Windows

### DIFF
--- a/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
+++ b/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
@@ -102,7 +102,7 @@ namespace Analyzer.Cli.FunctionalTests
         [TestMethod]
         public void AnalyzeDirectory_ValidInputValues_AnalyzesExpectedNumberOfFiles()
         {
-            var args = new string[] { "analyze-directory", Directory.GetCurrentDirectory() };
+            var args = new string[] { "analyze-directory", Path.Combine(Directory.GetCurrentDirectory(), "Tests") };
 
             using StringWriter outputWriter = new();
             Console.SetOut(outputWriter);

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
             this.includeNonSecurityRules = includeNonSecurityRules;
             this.logger = logger;
 
-            // We need to unlock the PowerShell scripts on Windows to allow them to run
+            // We need to unblock the PowerShell scripts on Windows to allow them to run
             // If a script is not unblocked, even if it's signed, PowerShell prompts for confirmation before executing
             // This prompting would throw an exception, because there's no interaction with a user that would allow for confirmation
             if (Platform.IsWindows)
@@ -65,8 +65,6 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
                     initialState.ExecutionPolicy = PowerShell.ExecutionPolicy.RemoteSigned;
 
                     var powershell = Powershell.Create(initialState);
-
-                    var path = Path.Combine(AppContext.BaseDirectory, "Modules");
 
                     powershell
                         .AddCommand("Get-ChildItem")

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -68,8 +68,9 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 
                     powershell
                         .AddCommand("Get-ChildItem")
-                        .AddParameter("Path", Path.Combine(AppContext.BaseDirectory, "Modules"))
+                        .AddParameter("Path", Path.Combine(AppContext.BaseDirectory, "Modules", "PSRule.Rules.Azure"))
                         .AddParameter("Recurse")
+                        .AddParameter("Filter", "*.ps1")
                         .AddCommand("Unblock-File")
                         .Invoke();
 
@@ -79,7 +80,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 
                         foreach (var error in powershell.Streams.Error)
                         {
-                            this.logger?.LogError(error.ErrorDetails.Message);
+                            this.logger?.LogError(error.ToString());
                         }
                     }
                 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,4 +4,17 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <!-- Move platform-specific runtime modules directly into the publish directory -->
+  <Target Name="UpdatePSRuntimeModules" AfterTargets="Publish">
+    <PropertyGroup>
+      <OSDirectory Condition="'$(OS)' == 'Unix'">unix</OSDirectory>
+      <OSDirectory Condition="'$(OS)' != 'Unix'">win</OSDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <Modules Include="$(PublishDir)\runtimes\$(OSDirectory)\lib\$(TargetFramework)\Modules\**\*" />
+    </ItemGroup>
+    <Move SourceFiles="@(Modules)" DestinationFolder="$(PublishDir)\Modules\%(RecursiveDir)" />
+    <RemoveDir Directories="$(PublishDir)\runtimes" />
+  </Target>
 </Project>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add an informative description that covers the changes made by the pull request. -->

Add back some logic to the PowerShellEngine that was originally added here: https://github.com/Azure/template-analyzer/commit/32146a5b7933875fda5126ab0e9190c2501b278c

We still need to unblock the PowerShell scripts on Windows to allow them to run. If a script is not unblocked, even if it's signed, PowerShell prompts for confirmation before executing. This prompting would throw an exception, because there's no interaction with a user that would allow for confirmation

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [x] I have added myself to the 'assignees'.
- [x] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [ ] Pull request includes test coverage for the included changes.
