### PR TITLE
ConsoleReportWriter quick fixes

### DIFF
--- a/src/Analyzer.Cli/CommandLineParser.cs
+++ b/src/Analyzer.Cli/CommandLineParser.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             }
 
             int numOfFilesAnalyzed = exitCodes.Where(x => x == ExitCode.Success || x == ExitCode.Violation).Count();
-            Console.WriteLine($"{Environment.NewLine}Analyzed {numOfFilesAnalyzed} {(numOfFilesAnalyzed == 1 ? "file" : "files")} in directory.");
+            Console.WriteLine($"{Environment.NewLine}Analyzed {numOfFilesAnalyzed} {(numOfFilesAnalyzed == 1 ? "file" : "files")} in the directory specified.");
 
             var exitCode = AnalyzeExitCodes(exitCodes);
 

--- a/src/Analyzer.Cli/CommandLineParser.cs
+++ b/src/Analyzer.Cli/CommandLineParser.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             }
 
             int numOfFilesAnalyzed = exitCodes.Where(x => x == ExitCode.Success || x == ExitCode.Violation).Count();
-            Console.WriteLine($"{Environment.NewLine}Analyzed {numOfFilesAnalyzed} {(numOfFilesAnalyzed == 1 ? "file" : "files")}.");
+            Console.WriteLine($"{Environment.NewLine}Analyzed {numOfFilesAnalyzed} {(numOfFilesAnalyzed == 1 ? "file" : "files")} in directory.");
 
             var exitCode = AnalyzeExitCodes(exitCodes);
 

--- a/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
+++ b/src/Analyzer.Reports.UnitTests/ConsoleReportWriterTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports.UnitTests
                 expected.Append($"{Environment.NewLine}{Environment.NewLine}Template: {TestCases.TestTemplateFilePath}");
             }
 
-            expected.Append($"{Environment.NewLine}{Environment.NewLine}Rules passed: {testcases.Count(e => e.Passed)}{Environment.NewLine}");
+            expected.Append($"{ConsoleReportWriter.IndentedNewLine}Rules passed: {testcases.Count(e => e.Passed)}{Environment.NewLine}");
             outputString.Should().BeEquivalentTo(expected.ToString());
         }
     }

--- a/src/Analyzer.Reports/ConsoleReportWriter.cs
+++ b/src/Analyzer.Reports/ConsoleReportWriter.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
                 {
                     if (parametersFile != null)
                     {
-                        fileMetadata += $"{IndentedNewLine}Parameters File: {parametersFile}";
+                        fileMetadata += $"{IndentedNewLine}Parameters File: {parametersFile.FullName}";
                     }
                 }
                 else
                 {
-                    fileMetadata += $"{IndentedNewLine}Root Template: {templateFile}";
+                    fileMetadata += $"{IndentedNewLine}Root Template: {templateFile.FullName}";
                 }
 
                 Console.WriteLine(fileMetadata);
@@ -62,17 +62,17 @@ namespace Microsoft.Azure.Templates.Analyzer.Reports
             // ensure filename output if there were no failed results
             if (filesWithResults.Count() == 0)
             {
-                var fileMetadata = $"{Environment.NewLine}{Environment.NewLine}Template: {templateFile}";
+                var fileMetadata = $"{Environment.NewLine}{Environment.NewLine}Template: {templateFile.FullName}";
                 if (parametersFile != null)
                 {
-                    fileMetadata += $"{Environment.NewLine}Parameters File: {parametersFile}";
+                    fileMetadata += $"{Environment.NewLine}Parameters File: {parametersFile.FullName}";
                 }
                 Console.WriteLine(fileMetadata);
             }
 
             filesAlreadyOutput.AddRange(filesWithResults);
 
-            Console.WriteLine($"{Environment.NewLine}Rules passed: {passedEvaluations}");
+            Console.WriteLine($"\tRules passed: {passedEvaluations}");
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
- Adds indentation back to "Rules passed" line
- Clarifying scanned file count for scanning directories (see #310)
- Changes all file paths to full paths for more consistency (see #311)
