### PR TITLE
Unblock PSRule rules without invoking PowerShell

### DIFF
--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Management.Automation;
-using System.Management.Automation.Runspaces;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 using Microsoft.Extensions.Logging;
@@ -13,7 +11,6 @@ using Newtonsoft.Json.Linq;
 using PSRule.Configuration;
 using PSRule.Pipeline;
 using PSRule.Rules;
-using Powershell = System.Management.Automation.PowerShell; // There's a conflict between this class name and a namespace
 
 namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
 {
@@ -50,7 +47,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
             // We need to unblock the PowerShell scripts on Windows to allow them to run.
             // If a script is not unblocked, even if it's signed, PowerShell prompts for confirmation before executing.
             // This prompting would throw an exception, because there's no interaction with a user that would allow for confirmation.
-            if (Platform.IsWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {

--- a/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
+++ b/src/Analyzer.PowerShellRuleEngine/PowerShellRuleEngine.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
     public class PowerShellRuleEngine : IRuleEngine
     {
         /// <summary>
+        /// The name of the module containing the PowerShell rules.
+        /// </summary>
+        private const string PSRuleModuleName = "PSRule.Rules.Azure";
+
+        /// <summary>
         /// Whether or not to run also non-security rules against the template.
         /// </summary>
         private readonly bool includeNonSecurityRules;
@@ -42,53 +47,19 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
             this.includeNonSecurityRules = includeNonSecurityRules;
             this.logger = logger;
 
-            // We need to unblock the PowerShell scripts on Windows to allow them to run
-            // If a script is not unblocked, even if it's signed, PowerShell prompts for confirmation before executing
-            // This prompting would throw an exception, because there's no interaction with a user that would allow for confirmation
+            // We need to unblock the PowerShell scripts on Windows to allow them to run.
+            // If a script is not unblocked, even if it's signed, PowerShell prompts for confirmation before executing.
+            // This prompting would throw an exception, because there's no interaction with a user that would allow for confirmation.
             if (Platform.IsWindows)
             {
                 try
                 {
-                    // There are 2 different 'Default' functions available:
-                    // https://docs.microsoft.com/en-us/powershell/scripting/developer/hosting/creating-an-initialsessionstate?view=powershell-7.2
-                    //
-                    // CreateDefault has a dependency on Microsoft.Management.Infrastructure.dll, which is missing when publishing for 'win-x64',
-                    // and PowerShell throws an exception creating the InitialSessionState.
-                    //
-                    // CreateDefault2 does NOT have this dependency.
-                    // Notably, Microsoft.Management.Infrastructure.dll is available when publishing for specific Windows versions (such as win7-x64),
-                    // but since this libary is not needed in our usage of PowerShell, we can eliminate the dependency.
-                    var initialState = InitialSessionState.CreateDefault2();
-
-                    // Ensure we can execute the signed bundled scripts
-                    // This sets the policy at the Process scope
-                    initialState.ExecutionPolicy = PowerShell.ExecutionPolicy.RemoteSigned;
-
-                    var powershell = Powershell.Create(initialState);
-
-                    powershell
-                        .AddCommand("Get-ChildItem")
-                        .AddParameter("Path", Path.Combine(AppContext.BaseDirectory, "Modules", "PSRule.Rules.Azure"))
-                        .AddParameter("Recurse")
-                        .AddParameter("Filter", "*.ps1")
-                        .AddCommand("Unblock-File")
-                        .Invoke();
-
-                    if (powershell.HadErrors)
-                    {
-                        this.logger?.LogError("There was an error unblocking the PowerShell scripts");
-
-                        foreach (var error in powershell.Streams.Error)
-                        {
-                            this.logger?.LogError(error.ToString());
-                        }
-                    }
+                    UnblockRules();
                 }
                 catch(Exception exception)
                 {
                     this.logger?.LogError(exception, "There was an exception while unblocking the PowerShell scripts");
                 }
-
             }
         }
 
@@ -124,7 +95,7 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
             try
             {
                 hostContext = new PSRuleHostContext(templateContext, logger);
-                var modules = new string[] { "PSRule.Rules.Azure" };
+                var modules = new string[] { PSRuleModuleName };
                 var optionsForFileAnalysis = new PSRuleOption
                 {
                     Input = new InputOption
@@ -181,6 +152,38 @@ namespace Microsoft.Azure.Templates.Analyzer.RuleEngines.PowerShellEngine
             }
 
             return hostContext.Evaluations;
+        }
+
+        /// <summary>
+        /// Unblocks the PSRule PowerShell scripts by deleting the Zone.Identifier Alternate Data Stream.
+        /// See https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/unblock-file#example-3-find-and-unblock-scripts for more information.
+        /// Creates a new Alternate Data Stream on the .psd1 module file to indicate that the rules have been unblocked.
+        /// </summary>
+        private void UnblockRules()
+        {
+            var rulesDirectory = Path.Combine(AppContext.BaseDirectory, "Modules", PSRuleModuleName);
+
+            // Check if rules have already been unblocked
+            var moduleFileAlternateDataStream = Path.Combine(rulesDirectory, $"{PSRuleModuleName}.psd1:Unblocked");
+            if (File.Exists(moduleFileAlternateDataStream))
+            {
+                return;
+            }
+
+            string[] ruleFiles = Directory.GetFiles(rulesDirectory, "*.ps1", new EnumerationOptions
+            {
+                RecurseSubdirectories = true,
+                MatchCasing = MatchCasing.CaseInsensitive
+            });
+
+            // Delete the Zone.Identifier Alternate Data Stream on each rule file
+            foreach (string ruleFile in ruleFiles)
+            {
+                File.Delete($"{ruleFile}:Zone.Identifier");
+            }
+
+            // Create a new Alternate Data Stream on the .psd1 module file to indicate that the rules have been unblocked
+            File.WriteAllBytes(moduleFileAlternateDataStream, new byte[0]);
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Since creating a PowerShell instance and invoking it requires extra processing, and leaves more opportunity for sporadic failures, this change removes that requirement when unblocking PSRule rule scripts during the initial creation of the PowerShell rule engine.

Instead of calling the PS command `Unblock-File`, native .NET file I/O is used directly to delete the [Alternate Data Stream (ADS)](https://learn.microsoft.com/openspecs/windows_protocols/ms-fscc/c54dec26-1551-4d3a-a0ea-4fa40f848eb3) in Windows that denotes a file was downloaded (the mechanism used for blocking PS scripts).  This is essentially what `Unblock-File` does behind the scenes, but should be much faster by doing it directly instead of through PowerShell.  After unblocking the scripts, an additional ADS is created on the PSRule *.psd1* module file to indicate unblocking has already been done, so it can be skipped on subsequent executions of Template Analyzer.


---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [x] I have added myself to the 'assignees'.
- [x] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [x] Pull request includes test coverage for the included changes.
