### PR TITLE
Handle uncaught exception in IsValidTemplate

### DIFF
--- a/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
+++ b/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
@@ -404,14 +404,14 @@ namespace Analyzer.Cli.FunctionalTests
         }
 
         [DataTestMethod]
-        [DataRow(TestcaseTemplateConstants.PassingTest, ExitCode.Success, DisplayName = "Valid Template")]
-        [DataRow(TestcaseTemplateConstants.SchemaCaseInsensitive, ExitCode.Success, DisplayName = "Schema is case insensitive")]
-        [DataRow(TestcaseTemplateConstants.DifferentSchemaDepths, ExitCode.Success, DisplayName = "Two schemas, different depths, valid schema last")]
-        [DataRow(TestcaseTemplateConstants.MissingStartObject, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Missing start object")]
-        [DataRow(TestcaseTemplateConstants.NoValidTopLevelProperties, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Invalid property depths")]
-        [DataRow(TestcaseTemplateConstants.MissingSchema, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Missing schema, capitalized property names")]
-        [DataRow(TestcaseTemplateConstants.SchemaValueNotString, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Schema value isn't string")]
-        [DataRow(TestcaseTemplateConstants.NoSchemaInvalidProperties, ExitCode.ErrorInvalidARMTemplate, DisplayName = "No schema, invalid properties")]
+        [DataRow(TestCaseTemplateConstants.PassingTest, ExitCode.Success, DisplayName = "Valid Template")]
+        [DataRow(TestCaseTemplateConstants.SchemaCaseInsensitive, ExitCode.Success, DisplayName = "Schema is case insensitive")]
+        [DataRow(TestCaseTemplateConstants.DifferentSchemaDepths, ExitCode.Success, DisplayName = "Two schemas, different depths, valid schema last")]
+        [DataRow(TestCaseTemplateConstants.MissingStartObject, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Missing start object")]
+        [DataRow(TestCaseTemplateConstants.NoValidTopLevelProperties, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Invalid property depths")]
+        [DataRow(TestCaseTemplateConstants.MissingSchema, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Missing schema, capitalized property names")]
+        [DataRow(TestCaseTemplateConstants.SchemaValueNotString, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Schema value isn't string")]
+        [DataRow(TestCaseTemplateConstants.NoSchemaInvalidProperties, ExitCode.ErrorInvalidARMTemplate, DisplayName = "No schema, invalid properties")]
         [DataRow(TestCaseTemplateConstants.UnexpectedCharacters, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Unexpected character, parsing fails")]
         public void IsValidTemplate_ValidAndInvalidInputTemplates_ReturnExpectedErrorCode(string templateToAnalyze, ExitCode expectedErrorCode)
         {

--- a/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
+++ b/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
@@ -412,6 +412,7 @@ namespace Analyzer.Cli.FunctionalTests
         [DataRow(TestcaseTemplateConstants.MissingSchema, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Missing schema, capitalized property names")]
         [DataRow(TestcaseTemplateConstants.SchemaValueNotString, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Schema value isn't string")]
         [DataRow(TestcaseTemplateConstants.NoSchemaInvalidProperties, ExitCode.ErrorInvalidARMTemplate, DisplayName = "No schema, invalid properties")]
+        [DataRow(TestCaseTemplateConstants.UnexpectedCharacters, ExitCode.ErrorInvalidARMTemplate, DisplayName = "Unexpected character, parsing fails")]
         public void IsValidTemplate_ValidAndInvalidInputTemplates_ReturnExpectedErrorCode(string templateToAnalyze, ExitCode expectedErrorCode)
         {
             var templatePath = Path.Combine(Directory.GetCurrentDirectory(), "output.json");

--- a/src/Analyzer.Cli.FunctionalTests/TestCaseTemplateConstants.cs
+++ b/src/Analyzer.Cli.FunctionalTests/TestCaseTemplateConstants.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Constants being passed in as test cases for the CommandLineParserTests.
     /// </summary>
-    public class TestcaseTemplateConstants
+    public class TestCaseTemplateConstants
     {
         // Pass
         public const string PassingTest = @"{
@@ -49,5 +49,8 @@
 
         // Fail
         public const string NoSchemaInvalidProperties = @" {""properties"": }";
+
+        // Fail
+        public const string UnexpectedCharacters = @"{ ""$schema"": �";
     }
 }

--- a/src/Analyzer.Utilities/TemplateDiscovery.cs
+++ b/src/Analyzer.Utilities/TemplateDiscovery.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
                 return false;
             }
             catch {
-                // if template fails to parse in any way then also consider invalid template
+                // If template fails to parse in any way then also consider invalid template
                 return false;
             }
         }

--- a/src/Analyzer.Utilities/TemplateDiscovery.cs
+++ b/src/Analyzer.Utilities/TemplateDiscovery.cs
@@ -108,43 +108,50 @@ namespace Microsoft.Azure.Templates.Analyzer.Utilities
         /// <returns>true if the file is a valid ARM template; false otherwise.</returns>
         public static bool IsValidTemplate(FileInfo file)
         {
-            // Assume bicep files are valid, they are compiled/verified later
-            if (file.Extension.Equals(".bicep", StringComparison.OrdinalIgnoreCase))
+            try
             {
-                return true;
-            }
-
-            using var fileStream = new StreamReader(file.OpenRead());
-            var reader = new JsonTextReader(fileStream);
-
-            reader.Read();
-            if (reader.TokenType != JsonToken.StartObject)
-            {
-                return false;
-            }
-
-            while (reader.Read())
-            {
-                if (reader.Depth == 1 && reader.TokenType == JsonToken.PropertyName)
+                // Assume bicep files are valid, they are compiled/verified later
+                if (file.Extension.Equals(".bicep", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (string.Equals((string)reader.Value, "$schema", StringComparison.OrdinalIgnoreCase))
+                    return true;
+                }
+
+                using var fileStream = new StreamReader(file.OpenRead());
+                var reader = new JsonTextReader(fileStream);
+
+                reader.Read();
+                if (reader.TokenType != JsonToken.StartObject)
+                {
+                    return false;
+                }
+
+                while (reader.Read())
+                {
+                    if (reader.Depth == 1 && reader.TokenType == JsonToken.PropertyName)
                     {
-                        reader.Read();
-                        if (reader.TokenType != JsonToken.String)
+                        if (string.Equals((string)reader.Value, "$schema", StringComparison.OrdinalIgnoreCase))
+                        {
+                            reader.Read();
+                            if (reader.TokenType != JsonToken.String)
+                            {
+                                return false;
+                            }
+
+                            return validSchemaRegex.IsMatch((string)reader.Value);
+                        }
+                        else if (!validTemplateProperties.Any(property => string.Equals((string)reader.Value, property, StringComparison.OrdinalIgnoreCase)))
                         {
                             return false;
                         }
-
-                        return validSchemaRegex.IsMatch((string)reader.Value);
-                    }
-                    else if (!validTemplateProperties.Any(property => string.Equals((string)reader.Value, property, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        return false;
                     }
                 }
-            }
 
-            return false;
+                return false;
+            }
+            catch {
+                // if template fails to parse in any way then also consider invalid template
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This fixes a reported customer issue with an uncaught exception in IsValidTemplate when parsing fails due to unexpected char. When scanning directories this potentially causes incomplete output to be written (e.g. incomplete SARIF).

```
     Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
      ---> Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: . Path '', line 1, position 1.
        at Newtonsoft.Json.JsonTextReader.ParseValue()
        at Microsoft.Azure.Templates.Analyzer.Cli.CommandLineParser.IsValidTemplate(FileInfo file)
        at System.Linq.Enumerable.WhereArrayIterator`1.MoveNext()
        at System.Linq.Enumerable.ConcatIterator`1.MoveNext()
        at Microsoft.Azure.Templates.Analyzer.Cli.CommandLineParser.AnalyzeDirectoryCommandHandler(DirectoryInfo directoryPath, FileInfo configFilePath, ReportFormat reportFormat, FileInfo outputFilePath, Boolean includeNonSecurityRules, Boolean verbose)
        --- End of inner exception stack trace ---
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [x] I have added myself to the 'assignees'.
- [x] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [ ] Pull request includes test coverage for the included changes.
