### PR TITLE
Added the ability to specify custom rules.json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Argument | Description
 `-o` or `--output-file-path` | **(Required if `--report-format` is *Sarif*)**  File path to output SARIF results to.
 **(Optional)** `-v` or `--verbose` | Shows details about the analysis
 **(Optional)** `--include-non-security-rules` | Run all the rules against the templates, including non-security rules
+**(Optional)** `--custom-json-rules-path` | The [JSON rules file](docs/authoring-json-rules.md) to use against the templates.<br/>If not specified, will use the [default JSON rule set that is shipped with the tool](docs/built-in-rules.md#json-based-rules).
 
  Template Analyzer runs the [configured rules](#understanding-and-customizing-rules) against the provided template and its corresponding [template parameters](https://docs.microsoft.com/azure/azure-resource-manager/templates/parameter-files), if specified. If no template parameters are specified, then Template Analyzer will check if templates with the [general naming standards defined by Microsoft](https://learn.microsoft.com/azure/azure-resource-manager/templates/parameter-files#file-name) are present in the same folder, otherwise it generates the minimum number of placeholder parameters to properly evaluate [template functions](https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions) in the template.
 

--- a/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
+++ b/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
@@ -135,7 +135,7 @@ namespace Analyzer.Cli.FunctionalTests
             };
 
             // Move rules file
-            File.Move(rulesFile, customJSONRulesPath, true);
+            File.Move(rulesFile, customJSONRulesPath, overwrite: true);
 
             try
             {

--- a/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
+++ b/src/Analyzer.Cli.FunctionalTests/CommandLineParserTests.cs
@@ -4,8 +4,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.Templates.Analyzer.Cli;
+using Microsoft.Azure.Templates.Analyzer.Core;
 using Microsoft.Azure.Templates.Analyzer.Types;
 using Microsoft.Azure.Templates.Analyzer.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -37,7 +39,7 @@ namespace Analyzer.Cli.FunctionalTests
         [DataRow("Invalid.bicep", ExitCode.ErrorInvalidBicepTemplate, DisplayName = "Path exists, invalid Bicep template")]
         public void AnalyzeTemplate_ValidInputValues_ReturnExpectedExitCode(string relativeTemplatePath, ExitCode expectedExitCode, params string[] additionalCliOptions)
         {
-            var args = new string[] { "analyze-template" , GetFilePath(relativeTemplatePath)}; 
+            var args = new string[] { "analyze-template", GetFilePath(relativeTemplatePath) };
             args = args.Concat(additionalCliOptions).ToArray();
             var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
 
@@ -64,7 +66,7 @@ namespace Analyzer.Cli.FunctionalTests
         {
             var templatePath = GetFilePath(relativeTemplatePath);
             var configurationPath = GetFilePath("Configuration.json");
-            var args = new string[] { "analyze-template", templatePath, "--config-file-path", configurationPath};
+            var args = new string[] { "analyze-template", templatePath, "--config-file-path", configurationPath };
             var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
 
             Assert.AreEqual((int)ExitCode.Violation, result.Result);
@@ -81,7 +83,7 @@ namespace Analyzer.Cli.FunctionalTests
             var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
 
             Assert.AreEqual((int)ExitCode.Violation, result.Result);
-            
+
             File.Delete(outputFilePath);
         }
 
@@ -115,6 +117,35 @@ namespace Analyzer.Cli.FunctionalTests
 
             Assert.AreEqual((int)ExitCode.Success, result.Result);
             StringAssert.Contains(outputWriter.ToString(), "Parameters File: " + Path.Combine(Directory.GetCurrentDirectory(), "Tests", "ToTestSeparateParametersFile", "TemplateWithSeparateParametersFile.parameters.json"));
+        }
+
+        [TestMethod]
+        public void AnalyzeTemplate_ValidInputValues_AnalyzesUsingCustomJSONRulesPath()
+        {
+            var rulesDir = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "Rules");
+            var rulesFile = Path.Combine(rulesDir, "BuiltInRules.json");
+            var customJSONRulesPath = Path.Combine(rulesDir, "MovedRules.json");
+            var templatePath = GetFilePath(Path.Combine("ToTestSeparateParametersFile", "TemplateWithSeparateParametersFile.bicep"));
+
+            var args = new string[] {
+                "analyze-template", templatePath,
+                "--custom-json-rules-path", customJSONRulesPath
+            };
+
+            // Move rules file
+            File.Move(rulesFile, customJSONRulesPath, true);
+
+            try
+            {
+                var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
+                Assert.AreEqual((int)ExitCode.Success, result.Result);
+            }
+            finally
+            {
+                File.Move(customJSONRulesPath, rulesFile, overwrite: true);
+            }
         }
 
         [TestMethod]
@@ -161,7 +192,7 @@ namespace Analyzer.Cli.FunctionalTests
 
             args = args.Concat(additionalCliOptions).ToArray();
             var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
-            
+
             Assert.AreEqual((int)expectedExitCode, result.Result);
         }
 
@@ -170,7 +201,7 @@ namespace Analyzer.Cli.FunctionalTests
         {
             var outputFilePath = Path.Combine(Directory.GetCurrentDirectory(), "Output.sarif");
             var directoryToAnalyze = GetFilePath("ToTestSarifNotifications");
-            
+
             var args = new string[] { "analyze-directory", directoryToAnalyze, "--report-format", "Sarif", "--output-file-path", outputFilePath };
 
             var result = _commandLineParser.InvokeCommandLineAPIAsync(args);
@@ -228,7 +259,7 @@ namespace Analyzer.Cli.FunctionalTests
                     $"{Environment.NewLine}\t\t1 instance of: {errorMessage1}" +
                     $"{Environment.NewLine}\t\t1 instance of: {errorMessage2}";
             }
-            
+
             expectedLogSummary += ($"{Environment.NewLine}{Environment.NewLine}\t1 Warning" +
                 $"{Environment.NewLine}\t{(multipleErrors ? "2 Errors" : "1 Error")}{Environment.NewLine}");
 
@@ -320,7 +351,7 @@ namespace Analyzer.Cli.FunctionalTests
                             }
                         })
                     .ToString());
-                
+
                 if (specifyInCommand)
                 {
                     args = args.Concat(new[] { "--config-file-path", configName }).ToArray();

--- a/src/Analyzer.Cli/CommandLineParser.cs
+++ b/src/Analyzer.Cli/CommandLineParser.cs
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
                     "Run all the rules against the templates, including non-security rules"),
 
                 new Option<FileInfo>(
-                    "--custom-rules-json-path",
-                    "The rules JSON file to use against the templates. If not specified, will use the default rule set that is shipped with the tool.")
+                    "--custom-json-rules-path",
+                    "The JSON rules file to use against the templates. If not specified, will use the default rule set that is shipped with the tool.")
             };
 
             commands.ForEach(c => options.ForEach(c.AddOption));
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
             bool verbose,
-            FileInfo customRulesJsonPath)
+            FileInfo customJsonRulesPath)
         {
             // Check that template file paths exist
             if (!templateFilePath.Exists)
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
                 return (int)ExitCode.ErrorInvalidPath;
             }
 
-            var setupResult = SetupAnalysis(configFilePath, directoryToAnalyze: null, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customRulesJsonPath);
+            var setupResult = SetupAnalysis(configFilePath, directoryToAnalyze: null, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customJsonRulesPath);
             if (setupResult != ExitCode.Success)
             {
                 return (int)setupResult;
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
             bool verbose,
-            FileInfo customRulesJsonPath)
+            FileInfo customJsonRulesPath)
         {
             if (!directoryPath.Exists)
             {
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
                 return (int)ExitCode.ErrorInvalidPath;
             }
 
-            var setupResult = SetupAnalysis(configFilePath, directoryPath, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customRulesJsonPath);
+            var setupResult = SetupAnalysis(configFilePath, directoryPath, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customJsonRulesPath);
             if (setupResult != ExitCode.Success)
             {
                 return (int)setupResult;
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
             bool verbose,
-            FileInfo customRulesJsonPath)
+            FileInfo customJsonRulesPath)
         {
             // Output file path must be specified if SARIF was chosen as the report format
             if (reportFormat == ReportFormat.Sarif && outputFilePath == null)
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             this.reportWriter = GetReportWriter(reportFormat, outputFilePath, directoryToAnalyze?.FullName);
             CreateLoggers(verbose);
 
-            this.templateAnalyzer = TemplateAnalyzer.Create(includeNonSecurityRules, this.logger, customRulesJsonPath);
+            this.templateAnalyzer = TemplateAnalyzer.Create(includeNonSecurityRules, this.logger, customJsonRulesPath);
 
             if (!TryReadConfigurationFile(configurationFile, out var config))
             {

--- a/src/Analyzer.Cli/CommandLineParser.cs
+++ b/src/Analyzer.Cli/CommandLineParser.cs
@@ -143,7 +143,11 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
 
                 new Option(
                     "--include-non-security-rules",
-                    "Run all the rules against the templates, including non-security rules")
+                    "Run all the rules against the templates, including non-security rules"),
+
+                new Option<FileInfo>(
+                    "--custom-rules-json-path",
+                    "The rules JSON file to use against the templates. If not specified, will use the default rule set that is shipped with the tool.")
             };
 
             commands.ForEach(c => options.ForEach(c.AddOption));
@@ -157,7 +161,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             ReportFormat reportFormat,
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
-            bool verbose)
+            bool verbose,
+            FileInfo customRulesJsonPath)
         {
             // Check that template file paths exist
             if (!templateFilePath.Exists)
@@ -166,7 +171,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
                 return (int)ExitCode.ErrorInvalidPath;
             }
 
-            var setupResult = SetupAnalysis(configFilePath, directoryToAnalyze: null, reportFormat, outputFilePath, includeNonSecurityRules, verbose);
+            var setupResult = SetupAnalysis(configFilePath, directoryToAnalyze: null, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customRulesJsonPath);
             if (setupResult != ExitCode.Success)
             {
                 return (int)setupResult;
@@ -203,7 +208,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             ReportFormat reportFormat,
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
-            bool verbose)
+            bool verbose,
+            FileInfo customRulesJsonPath)
         {
             if (!directoryPath.Exists)
             {
@@ -211,7 +217,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
                 return (int)ExitCode.ErrorInvalidPath;
             }
 
-            var setupResult = SetupAnalysis(configFilePath, directoryPath, reportFormat, outputFilePath, includeNonSecurityRules, verbose);
+            var setupResult = SetupAnalysis(configFilePath, directoryPath, reportFormat, outputFilePath, includeNonSecurityRules, verbose, customRulesJsonPath);
             if (setupResult != ExitCode.Success)
             {
                 return (int)setupResult;
@@ -278,7 +284,8 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             ReportFormat reportFormat,
             FileInfo outputFilePath,
             bool includeNonSecurityRules,
-            bool verbose)
+            bool verbose,
+            FileInfo customRulesJsonPath)
         {
             // Output file path must be specified if SARIF was chosen as the report format
             if (reportFormat == ReportFormat.Sarif && outputFilePath == null)
@@ -290,7 +297,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Cli
             this.reportWriter = GetReportWriter(reportFormat, outputFilePath, directoryToAnalyze?.FullName);
             CreateLoggers(verbose);
 
-            this.templateAnalyzer = TemplateAnalyzer.Create(includeNonSecurityRules, this.logger);
+            this.templateAnalyzer = TemplateAnalyzer.Create(includeNonSecurityRules, this.logger, customRulesJsonPath);
 
             if (!TryReadConfigurationFile(configurationFile, out var config))
             {

--- a/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
+++ b/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Templates.Analyzer.Core.UnitTests
             var movedFile = Path.Combine(rulesDir, "MovedRules.json");
 
             // Move rules file
-            File.Move(rulesFile, movedFile);
+            File.Move(rulesFile, movedFile, overwrite: true);
 
             var customRulesFile = new FileInfo(movedFile);
 

--- a/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
+++ b/src/Analyzer.Core.UnitTests/TemplateAnalyzerTests.cs
@@ -227,6 +227,30 @@ namespace Microsoft.Azure.Templates.Analyzer.Core.UnitTests
         }
 
         [TestMethod]
+        public void CustomRulesFileIsProvided_NoExceptionThrown()
+        {
+            var rulesDir = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "Rules");
+            var rulesFile = Path.Combine(rulesDir, "BuiltInRules.json");
+            var movedFile = Path.Combine(rulesDir, "MovedRules.json");
+
+            // Move rules file
+            File.Move(rulesFile, movedFile);
+
+            var customRulesFile = new FileInfo(movedFile);
+
+            try
+            {
+                TemplateAnalyzer.Create(false, null, customRulesFile);
+            }
+            finally
+            {
+                File.Move(movedFile, rulesFile, overwrite: true);
+            }
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void FilterRules_ConfigurationNull_ExceptionThrown()
         {

--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -51,13 +51,14 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
         /// </summary>
         /// <param name="includeNonSecurityRules">Whether or not to run also non-security rules against the template.</param>
         /// <param name="logger">A logger to report errors and debug information</param>
+        /// <param name="customRulesJsonPath">An optional custom rules json file path.</param>
         /// <returns>A new <see cref="TemplateAnalyzer"/> instance.</returns>
-        public static TemplateAnalyzer Create(bool includeNonSecurityRules, ILogger logger = null)
+        public static TemplateAnalyzer Create(bool includeNonSecurityRules, ILogger logger = null, FileInfo customRulesJsonPath = null)
         {
             string rules;
             try
             {
-                rules = LoadRules();
+                rules = LoadRules(customRulesJsonPath);
             }
             catch (Exception e)
             {
@@ -224,12 +225,16 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
             }
         }
 
-        private static string LoadRules()
+        private static string LoadRules(FileInfo rulesFile)
         {
-            return File.ReadAllText(
-                Path.Combine(
+            rulesFile ??= new FileInfo(Path.Combine(
                     Path.GetDirectoryName(AppContext.BaseDirectory),
                     "Rules/BuiltInRules.json"));
+
+            using var fileStream = rulesFile.OpenRead();
+            using var streamReader = new StreamReader(fileStream);
+
+            return streamReader.ReadToEnd();
         }
 
         /// <summary>

--- a/src/Analyzer.Core/TemplateAnalyzer.cs
+++ b/src/Analyzer.Core/TemplateAnalyzer.cs
@@ -51,14 +51,14 @@ namespace Microsoft.Azure.Templates.Analyzer.Core
         /// </summary>
         /// <param name="includeNonSecurityRules">Whether or not to run also non-security rules against the template.</param>
         /// <param name="logger">A logger to report errors and debug information</param>
-        /// <param name="customRulesJsonPath">An optional custom rules json file path.</param>
+        /// <param name="customJsonRulesPath">An optional custom rules json file path.</param>
         /// <returns>A new <see cref="TemplateAnalyzer"/> instance.</returns>
-        public static TemplateAnalyzer Create(bool includeNonSecurityRules, ILogger logger = null, FileInfo customRulesJsonPath = null)
+        public static TemplateAnalyzer Create(bool includeNonSecurityRules, ILogger logger = null, FileInfo customJsonRulesPath = null)
         {
             string rules;
             try
             {
-                rules = LoadRules(customRulesJsonPath);
+                rules = LoadRules(customJsonRulesPath);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
In this PR I've added the `--custom-rules-json-path` CLI parameter to be able to specify a custom `Rules.Json` file location.
This is required to inject custom rules that are not part of the basic functionality included with Template Analyzer.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [V] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [V] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [V] Title of the pull request is clear and informative.
- [V] Description of the pull request is clear and informative.
- [V] I have added myself to the 'assignees'.
- [V] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [V] Pull request includes test coverage for the included changes.
