### PR TITLE
Use Ubuntu 22.04 in build workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
         - os: windows-latest
           osLabel: Windows
           runtimeId: win-x64
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           osLabel: Linux
           runtimeId: linux-x64
     

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-22.04]
         include:
         - os: windows-latest
           osLabel: Windows


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
GitHub [started rolling out Ubuntu 24.04](https://github.com/actions/runner-images/issues/10636) over the last month, which our workflow picked up automatically by specifying `ubuntu-latest` as the Linux image name.

There is a breaking change between 22.04 (used previously) and 24.04 in which the mono software package is no longer installed on the image. (The note in the table at the link says software not available. `dotnet` still runs and builds without issue, so I don't quite fully understand the extent of it, but nuget commands aren't working without mono.)

This change pins Ubuntu to 22.04 while mono is missing from 24.04.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] The pull request does not introduce breaking changes.

### [General Guidelines](../CONTRIBUTING.md)
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request is clear and informative.
- [x] I have added myself to the 'assignees'.
- [x] I have added 'linked issues' if relevant.

### [Testing Guidelines](../CONTRIBUTING.md#tests)
- [x] Pull request includes test coverage for the included changes.
