### PR TITLE
Rename CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: "CodeQL Advanced"
 
 on:
   push:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Trying to understand GitHub's detection of CodeQL setup and enablement of required workflows: renaming the CodeQL advanced setup workflow back to its default.
